### PR TITLE
uslims_git_info.php: allow site-specific git repo ignores

### DIFF
--- a/db_config.php.template
+++ b/db_config.php.template
@@ -76,6 +76,13 @@ $usage_consolidation_add =
     ];
 
 
+## uslims_git_info.php: additional regexps of directory names to ignore when discovering git repos
+## (e.g. unexpected vendored repos like PHPMailer found on some client systems)
+
+$ignore_repos_add =
+    [
+    ];
+
 ## git branches
 
 $repo_branches =

--- a/uslims_git_info.php
+++ b/uslims_git_info.php
@@ -24,6 +24,7 @@ $reposearchpaths =
 
 ## regexp list of directory names to ignore
 $ignore_repos = [ '/undrop-for-innodb/' ];
+## additional site-specific ignores can be added via $ignore_repos_add in db_config.php
 
 # user defines continued
 $known_repos =
@@ -276,6 +277,13 @@ and edit with appropriate values
 
 file_perms_must_be( $use_config_file );
 require $use_config_file;
+
+if ( isset( $ignore_repos_add ) ) {
+    if ( !is_array( $ignore_repos_add ) ) {
+        error_exit( "\$ignore_repos_add is improperly defined, check $use_config_file" );
+    }
+    $ignore_repos = array_merge( $ignore_repos, $ignore_repos_add );
+}
 
 if ( $update_pull_build && !$update_pull ) {
     error_exit( "\nOption --update_pull_build requires --update_pull to be specified.\n\n$notes" );


### PR DESCRIPTION
## Summary
- Some client sites have unexpected vendored git repos under the search paths (e.g. PHPMailer found under `cch/admin/PHPMailer` on uslims.uleth.ca) that get discovered by `uslims_git_info.php` and reported as `Use:unknown` noise.
- Adds a per-site `$ignore_repos_add` array in `db_config.php`, merged into the script's existing `$ignore_repos` regexp list, so sites can suppress reporting on their own unexpected repos without modifying the script.

Fixes ehb54/ultrascan-tickets#926

## Test plan
- [x] Syntax-checked `uslims_git_info.php` with `php -l` via docker (php:7.2.24-cli)
- [ ] On uslims.uleth.ca, add `$ignore_repos_add = [ '/PHPMailer/' ];` to `db_config.php` and confirm `uslims_git_info.php` no longer reports the PHPMailer repo as `Use:unknown`
