### PR TITLE
Add autoflow/submitctl/submitone debug, monitor & test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ mariadb-binary-backup-*
 schemas-*
 my.cnf
 training
+test_bin/sbatch
+test_bin/state/

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -209,8 +209,16 @@ argv-parsing + `utility.php` convention.
   `analysisprofile` rows orphaned. Fixed by having `watch_request()` capture
   `autoflowID`/`aprofileGUID` from the last row it actually polled (kept even if
   the row later disappears) and passing those straight into `cleanup_request()`,
-  which now also deletes from `autoflowAnalysisHistory`. Not yet re-verified
-  live after this fix.
+  which now also deletes from `autoflowAnalysisHistory`.
+- 2026-06-24: fix re-verified live. Re-ran `--fake-sbatch fail-once` (still
+  PASS, no regression - job recognized immediately on attempt 2, no
+  duplicates) and `--fake-sbatch fail-always` again: all 4 attempts failed as
+  injected, row was archived into `autoflowAnalysisHistory` exactly as before,
+  but `--cleanup` now reports `removing test data for requestID=2480 (autoflow
+  ID=2482, analysisprofile aprofileGUID=...)` using the IDs captured during
+  the watch, instead of the earlier "not found" - `RESULT: PASS`, no orphaned
+  rows. Both fault-injection modes (`fail-once`, `fail-always`) and the
+  cleanup fix are now fully validated live.
 - Not yet validated live: non-2dsa scenarios (`pcsa`, `pcsa-onechannel`,
   `mc-cluster`, `cg`).
 

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -97,8 +97,11 @@ argv-parsing + `utility.php` convention.
   owner/group/permission bits + `id -nG` group membership — **not** PHP's
   `is_writable()`, which silently lies when the harness itself runs as root;
   `elog.txt`/`elog2.txt` are checked against both `--expected-user` and
-  `--web-user` (default `apache`) since browser-triggered submissions can write
-  those directly; and a stale-`autoflowAnalysis`-rows query.
+  `--web-user` (default: auto-detected from the running httpd/apache2/nginx/
+  php-fpm worker's actual owner, falling back to `apache` — some deployments,
+  e.g. uslimstest, run web workers as `us3` rather than a literal `apache`
+  account) since browser-triggered submissions can write those directly; and a
+  stale-`autoflowAnalysis`-rows query.
 - `--run --invid <id> --rawid <id> --scenario <name>`: drives a fresh request via
   one of the `makeafrequest*.php` variants, then watches/tails it, interleaving
   every log file in the inventory above. `--gridctl-dir` defaults to
@@ -124,7 +127,12 @@ argv-parsing + `utility.php` convention.
   restarts `submitctl.php` via the existing `services.php restart` with that dir
   prepended to `PATH`, runs the scenario, then restores the original `PATH`
   afterward. `test_bin/sbatch` and `test_bin/state/` are gitignored (regenerated each
-  run); `test_bin/` itself is tracked so the directory exists.
+  run); `test_bin/` itself is tracked so the directory exists. Both restarts run
+  as `--expected-user` via `su` (gridctl's `services.php:start()` does no
+  privilege-dropping itself — it inherits whoever calls `php services.php
+  restart`), so `submitctl.php` ends up owned by the same user it started as
+  regardless of which user runs this script; requires running as root or as
+  `--expected-user` itself.
 
 ## Status
 
@@ -154,8 +162,13 @@ argv-parsing + `utility.php` convention.
   `autoflow`/`analysisprofile`/`autoflowAnalysis` rows it created. Full happy path
   (`--check`, multi-stage `--run`, `WAIT`-awareness, `--cleanup`) confirmed working
   together.
-- Not yet validated live: `--fake-sbatch fail-always`/`fail-once`, non-2dsa
-  scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
+- 2026-06-23: found (before any live `--fake-sbatch` testing) that the
+  `submitctl.php` restart it performs would inherit whatever user runs this
+  script rather than preserving the daemon's real owner — fixed by routing both
+  restarts through `su -s /bin/bash -c ... $expected_user` instead of running
+  `services.php restart` directly from the harness's own process.
+- Not yet validated live: `--fake-sbatch fail-always`/`fail-once` (about to be
+  tested), non-2dsa scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -116,6 +116,13 @@ argv-parsing + `utility.php` convention.
   human to act in the desktop client, so a `2dsa`-scenario run will always end at
   `WAIT` there. `--expect-status` (default `FINISHED`) accepts `WAIT`/`FAILED`
   as valid pass conditions for scenarios that are expected to land there.
+  On a successful finish, `submitctl.php` sets `status='FINISHED'` and archives
+  the row into `autoflowAnalysisHistory` (deleting it from `autoflowAnalysis`)
+  in the very same poll tick (submitctl.php:349-409) - there is no stable window
+  for a poller to observe `FINISHED` live. So when the row disappears from
+  `autoflowAnalysis`, `watch_request()` checks `autoflowAnalysisHistory` before
+  concluding the request failed/hung, and uses that archived row as the final
+  result if found.
 - `--cleanup` (opt-in, `--run` only): after the watch ends regardless of outcome,
   deletes the `autoflow`/`analysisprofile`/`autoflowAnalysis`/
   `autoflowAnalysisHistory` rows that `--run` itself created. Never applies to
@@ -219,8 +226,23 @@ argv-parsing + `utility.php` convention.
   the watch, instead of the earlier "not found" - `RESULT: PASS`, no orphaned
   rows. Both fault-injection modes (`fail-once`, `fail-always`) and the
   cleanup fix are now fully validated live.
-- Not yet validated live: non-2dsa scenarios (`pcsa`, `pcsa-onechannel`,
-  `mc-cluster`, `cg`).
+- 2026-06-24: `--scenario pcsa` and `--scenario pcsa-onechannel`
+  (`--expect-status FINISHED`) both ran PCSA for real on the cluster (jobs
+  295/296) and genuinely finished, but the harness reported `RESULT:
+  requestID ... disappeared mid-watch - FAIL` for both. Root-caused to
+  `submitctl.php` setting `status='FINISHED'` and archiving the row into
+  `autoflowAnalysisHistory` (deleting it from `autoflowAnalysis`) within the
+  same poll tick (submitctl.php:349-409) - unlike `FAILED` (written
+  asynchronously by `submitone.php`'s `fail_job()` well before submitctl's next
+  archiving pass), there's no window where `FINISHED` is observable live. This
+  hadn't surfaced before because `2dsa` always stops at `WAIT` (never
+  archived); `pcsa`/`pcsa-onechannel` are the first scenarios that actually
+  reach a real `FINISHED`. Fixed by having `watch_request()` check
+  `autoflowAnalysisHistory` for the row when it disappears from
+  `autoflowAnalysis`, before concluding FAIL - cleanup (already ID-capture
+  based, see above) is unaffected. Not yet re-verified live after this fix.
+- Not yet validated live: `mc-cluster`, `cg` scenarios; re-verification of the
+  `pcsa`/`pcsa-onechannel` FINISHED-detection fix above.
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -86,6 +86,40 @@ ssh) — but ssh-connected remote clusters are a near-future target, so the
 fault-injection design stays extensible to "fake ssh" later even though v1 only
 fakes local `sbatch`.
 
+## Known gap: remote-cluster result retrieval not implemented (`mc-cluster` scenario)
+
+`makeafrequest2DSA_MC_cluster.php` (`--scenario mc-cluster`) sets up a single-stage
+(`to_process:["2DSA_MC"]`) request tagged with a caller-supplied `cluster` name,
+specifically to exercise submitting to a *named* cluster rather than always
+`us3iab-node0` — including genuinely remote clusters (`anvil`, `expanse`,
+`lonestar6`, etc.).
+
+Investigated 2026-06-24 (prompted by a user recollection that remote-cluster
+result retrieval was never finished):
+- `us3lims_common/class/submit_local.php` **does** support remote submission over
+  `ssh`/`scp` for clusters with a `login` config (`submit_local.php:56-86`).
+- `us3lims_gridctl/jobmonitor/gridctl.php`'s `get_local_status()` **does** support
+  remote status polling via `ssh ... squeue -t all -j $gfacID`
+  (`gridctl.php:838-845`), so a remote job's RUNNING/COMPLETE state can be
+  detected.
+- `us3lims_gridctl/jobmonitor/cleanup_gfac.php` — the code that processes a
+  finished job's actual output and writes results back into `autoflowAnalysis`/
+  `HPCAnalysisResult` — has **no `ssh`/`scp` anywhere in it**. It only knows how
+  to read result files that are already sitting in the local work directory.
+
+Net effect: remote *submission* and remote *status polling* exist, but remote
+*result retrieval* (copying the output tarball back from the remote cluster
+before cleanup processes it) was never built. A real run against a genuinely
+remote `cluster` value would likely submit fine and even report COMPLETE via the
+ssh-based status check, then hang or fail at result processing with nothing to
+read locally.
+
+Decision: `--scenario mc-cluster` is **disabled** in the harness (hard
+`error_exit()` in the `--run` case, pointing back to this section) until that
+retrieval code is written in `us3lims_gridctl`/`us3lims_common`. This is a
+real-system gap, not a harness bug — re-enable the scenario once remote result
+retrieval exists.
+
 ## Implementation: `uslims_autoflow_test.php`
 
 Lives at the repo root, following the `uslims_autoflow.php`/`uslims_jobs.php`
@@ -256,8 +290,15 @@ argv-parsing + `utility.php` convention.
   clear message if it's missing rather than failing inside
   `makeafrequest2DSA-CG.php`. Not yet re-tested live with a real
   `--customgrid` value.
-- Not yet validated live: `mc-cluster` scenario; `cg` scenario with a real
-  `--customgrid` value.
+- 2026-06-24: investigated `mc-cluster` (remote-cluster submission) at the user's
+  request and confirmed a real-system gap - `jobmonitor/cleanup_gfac.php` has no
+  ssh/scp result-retrieval path for non-local clusters, even though remote
+  submission (`submit_local.php`) and remote status polling (`gridctl.php`'s
+  `get_local_status()`) both exist. See the new "Known gap: remote-cluster result
+  retrieval not implemented" section above. `--scenario mc-cluster` is now disabled
+  in the harness (hard `error_exit()`) until that retrieval code is written -
+  intentionally disabled, not "not yet validated."
+- Not yet validated live: `cg` scenario with a real `--customgrid` value.
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -1,0 +1,119 @@
+# us3lims autoflow/submitctl/submitone test harness
+
+Tracking issue: ehb54/ultrascan-tickets#930
+
+## Context
+
+The original trigger for this work was a stuck CLI job submission
+(`makeafrequest.php` → `autoflowAnalysis` row stuck at `status=READY`) on a
+us3lims_gridctl deployment. Root cause turned out to be file-permission issues for
+the `services.php`-managed daemons (`submitctl.php`), not a code bug.
+
+That investigation exposed how easy it is for this pipeline to fail silently partway
+through (daemon not running, stale lock, permission issue, a transient `sbatch`
+failure) with no easy way to reproduce or watch it happening. The result: a **PHP CLI
+test harness** that can drive the full autoflow pipeline end-to-end, watch every part
+of it live, and (eventually) assert pass/fail for regression testing — including
+deliberately injecting `sbatch` failures to exercise the failure paths (PR
+ehb54/us3lims_gridctl#27's `check_cli_errors_in_dump()`, `submitctl.php`'s
+FAILED/`scancel` handling, and `submit_local.php`'s retry/backoff in
+`attemptSubmit()`).
+
+## The pipeline being tested (for reference)
+
+1. `us3lims_gridctl/autoflow_util/makeafrequest*.php <db> <invID> <rawID>` inserts
+   `autoflow` / `analysisprofile` / `autoflowAnalysis` rows. `statusJson` starts as
+   `{"to_process":[stage, stage, ...]}`. Several variants exist for different job
+   shapes (`makeafrequest.php` = plain 2DSA chain, `makeafrequestPCSA*.php`,
+   `makeafrequest2DSA_MC_cluster.php`, `makeafrequest2DSA-CG.php` — the latter is the
+   most recently touched, Sep 2025).
+2. `us3lims_gridctl/submitctl.php` — long-running daemon, polls every
+   `$poll_sleep_seconds` (30s). State machine driven by `$failed_status`,
+   `$completed_status`, `$wait_status` maps (submitctl.php:33-35) checked against
+   `autoflowAnalysis.status`. On each tick (submitctl.php:280-370ish):
+   - WAIT status + `nextWaitStatus` set → clears to `nextWaitStatus`
+   - row marked `processing_key` ("submitted") and not yet completed/failed → skip (still in flight)
+   - completed/failed → archive current stage into `statusJson.processed[]`
+   - more `to_process` left and not failed → shift next stage into `submitted`, set
+     `status='READY'`, **spawn** `php submitone.php $lims_db $ID >> submit.log 2>&1 &`
+   - nothing left and completed → `status='FINISHED'`
+   - failed → `scancel` the grid job if slurm
+3. `us3lims_gridctl/submitone.php` — does the actual submission for one stage. Builds
+   fake `$_SESSION`/`$_POST` from the `people` row (no browser session needed), then
+   `include()`s `queue_setup_1.php`, `queue_setup_2.php` (which chains
+   `queue_setup_3.php`) and the job-type page, capturing all output via
+   `ob_start("dump_it")` into `$dumpfilebase/$lims_db-$ID.txt`
+   (`/home/us3/lims/etc/submit/<db>-<ID>.txt`). `check_cli_errors()` /
+   `check_cli_errors_in_dump()` (PR #27) scan that dump for `ERROR:` lines and call
+   `fail_job()` → sets `autoflowAnalysis.status='FAILED'`.
+4. The actual grid submission happens deep inside the included pages, eventually
+   reaching `us3lims_common/class/submit_local.php:submit_job()` →
+   `attemptSubmit()`, which runs `sbatch --get-user-env $workdir/us3.slurm` directly
+   for local/slurm clusters with no `login` override, or over `ssh` for remote
+   clusters (`submit_local.php:488-553`). Retries/backoff are controlled by
+   `$global_sbatch_submit_retries` / `$global_sbatch_submit_retry_wait_seconds`
+   (default 3 retries, 5s doubling backoff), overridable per-cluster.
+
+## Complete log file inventory for the pipeline
+
+Several independent log files get written to during a single submission, by
+different layers — the harness watches **all** of them, not just `submit.log`,
+since a failure can show up in any one of them and nowhere else:
+
+| File | Written by | What ends up in it |
+|---|---|---|
+| `$home/etc/udp.log` (e.g. `/home/us3/lims/etc/udp.log`) | `write_log()` (`listen-config.php.template:42-49`), called via `write_logl()`/`write_logls()` in both `submitctl.php` and `submitone.php` | The daemons' own internal logging (poll cycles, state transitions, DB query failures) — this is `submitctl.php`/`submitone.php`'s "narration" of what they're doing, separate from any stdout capture |
+| `$home/etc/submit.log` | shell redirect set up by `submitctl.php:342` (`php submitone.php ... >> $home/etc/submit.log 2>&1 &`) | Raw stdout+stderr of each spawned `submitone.php` process — includes its `echo`/`write_logl` lines, PHP warnings/fatals, and anything the included pages print outside output buffering |
+| `$dumpfilebase/$lims_db-$ID.txt` (e.g. `/home/us3/lims/etc/submit/<db>-<ID>.txt`) | `submitone.php`'s `dump_it()` (submitone.php:308-313) via `ob_start("dump_it")` around each included page | Per-request capture of everything the included web pages (`queue_setup_1/2/3.php`, job-type pages) would have sent to a browser — this is what `check_cli_errors_in_dump()` (PR #27) scans for `ERROR:` lines |
+| `$us3home/lims/etc/elog.txt` | `elog()` in `us3lims_dbinst/elog.php:11-19` | Only fires for messages containing the string `"queue_content"` — i.e. logging from `queue_content.php` (included as part of the queue-setup chain) and anything else that deliberately mentions queue_content. Easy to miss since it's conditional, not a general-purpose log |
+| `/home/us3/lims/etc/elog2.txt` | `elog2()` in `us3lims_common/class/submit_local.php:11-14` | The actual `sbatch`/`qsub` submission attempts: command run, exit status, stdout line 0, retry/backoff messages, and the final FAILED/success outcome from `attemptSubmit()`/`submit_job()` — **this is the most direct evidence of an `sbatch` failure**, more so than `submit.log` |
+| PHP's default error log (`php.ini` `error_log` destination — typically the web server's error log, e.g. Apache's `error.log`, since these pages are normally run in a web context) | bare `error_log($emsg)` calls with no explicit file, in `us3lims_common/class/jobsubmit.php:28` and `jobsubmit_aira.php:28` | Generic job-submission error messages from the base `jobsubmit` class — easy to miss because it's not one of the app's custom log files at all |
+| `$priority_config['logfile']` (path defined in deployment-only `priority_config.php`, not in any repo) | `priority_log()` in `us3lims_common/class/priority.php:31-42` | Job priority/nice calculations — only written if `priority_config.php` exists and enables `'log' => true`; optional but worth checking for if it's configured on the target system |
+| `$output_dir/$db-$requestID-messages.txt` | `cleanup.php` / `cleanup_gfac.php` (both the legacy root copies and the current `jobmonitor/` copies in `us3lims_gridctl`) | Post-completion cleanup messages (this is the file involved in an earlier-found GMP tarfile race condition) — not part of submission proper, but part of "the entire process" end-to-end since it covers what happens after a stage finishes |
+
+## Design constraint: non-invasive, "work around" existing code
+
+The harness must **never modify** `us3lims_gridctl` or `us3lims_common` source
+(`submitctl.php`, `submitone.php`, `services.php`, `submit_local.php`, etc.) — no test
+hooks, no patched copies. It's a standalone, additive tool in `us3lims_dbutils` that
+observes/validates the existing system from outside (DB queries, log tailing,
+filesystem/process inspection), so it can be dropped onto a current *or older*
+deployed client machine as-is and used purely as a diagnostic. It doubles as a deep
+debug/monitoring/validation tool, not just a pipeline runner.
+
+Today autoflow/GMP only ever submits to `localhost` (`us3iab-node0`, local slurm, no
+ssh) — but ssh-connected remote clusters are a near-future target, so the
+fault-injection design stays extensible to "fake ssh" later even though v1 only
+fakes local `sbatch`.
+
+## Implementation: `uslims_autoflow_test.php`
+
+Lives at the repo root, following the `uslims_autoflow.php`/`uslims_jobs.php`
+argv-parsing + `utility.php` convention.
+
+- `--check` (default, read-only): `services.php status`, lock-file PID/owner checks
+  against `--expected-user` (default `us3`, configurable), writability/ownership of
+  the shared log/lock paths, and a stale-`autoflowAnalysis`-rows query.
+- `--run --gridctl-dir <path> --invid <id> --rawid <id> --scenario <name>`: drives a
+  fresh request via one of the `makeafrequest*.php` variants, then watches/tails it
+  to `FINISHED`/`FAILED`/timeout, interleaving every log file in the inventory above.
+  Exits 0 if the final status matches `--expect-status` (default `FINISHED`).
+- `--watch --reqid N`: same watch/tail behavior for an already-existing request.
+- `--fake-sbatch fail-always|fail-once` (opt-in, gated behind
+  `--yes-i-know-this-restarts-submitctl`): writes a fake `sbatch` into `test_bin/`,
+  restarts `submitctl.php` via the existing `services.php restart` with that dir
+  prepended to `PATH`, runs the scenario, then restores the original `PATH`
+  afterward. `test_bin/sbatch` and `test_bin/state/` are gitignored (regenerated each
+  run); `test_bin/` itself is tracked so the directory exists.
+
+## Verification
+- Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain
+  request end-to-end, confirm it traces every status transition through to
+  `FINISHED` and exits 0.
+- Run with `--fake-sbatch fail-always`, confirm it traces through to `FAILED` with
+  the expected `ERROR:`-derived `statusMsg`, exits non-zero, and that `scancel`
+  logic in `submitctl.php` is not erroneously triggered (no real job was ever
+  submitted).
+- Run with `--fake-sbatch fail-once`, confirm the retry/backoff path in
+  `submit_local.php::attemptSubmit()` is exercised and the job still ultimately
+  succeeds.

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -91,14 +91,34 @@ fakes local `sbatch`.
 Lives at the repo root, following the `uslims_autoflow.php`/`uslims_jobs.php`
 argv-parsing + `utility.php` convention.
 
-- `--check` (default, read-only): `services.php status`, lock-file PID/owner checks
-  against `--expected-user` (default `us3`, configurable), writability/ownership of
-  the shared log/lock paths, and a stale-`autoflowAnalysis`-rows query.
-- `--run --gridctl-dir <path> --invid <id> --rawid <id> --scenario <name>`: drives a
-  fresh request via one of the `makeafrequest*.php` variants, then watches/tails it
-  to `FINISHED`/`FAILED`/timeout, interleaving every log file in the inventory above.
-  Exits 0 if the final status matches `--expect-status` (default `FINISHED`).
+- `--check` (default, read-only): `services.php status`; lock-file PID/owner checks
+  against `--expected-user` (default `us3`); writability of the shared log/lock
+  *paths and files* (not just directories) computed from each file's actual
+  owner/group/permission bits + `id -nG` group membership — **not** PHP's
+  `is_writable()`, which silently lies when the harness itself runs as root;
+  `elog.txt`/`elog2.txt` are checked against both `--expected-user` and
+  `--web-user` (default `apache`) since browser-triggered submissions can write
+  those directly; and a stale-`autoflowAnalysis`-rows query.
+- `--run --invid <id> --rawid <id> --scenario <name>`: drives a fresh request via
+  one of the `makeafrequest*.php` variants, then watches/tails it, interleaving
+  every log file in the inventory above. `--gridctl-dir` defaults to
+  `~us3/lims/bin` (where the daemon scripts and `autoflow_util/` are normally
+  deployed) and only needs overriding for non-standard layouts.
 - `--watch --reqid N`: same watch/tail behavior for an already-existing request.
+- Both `--run` and `--watch` stop on `FINISHED`, `FAILED`, **or `WAIT`** (status
+  comparisons are case-insensitive, since the column mixes daemon-set uppercase
+  values like `READY`/`FINISHED` with lowercase job-state values like `wait`).
+  `WAIT` is reported as an expected stop, not a hang/timeout — stages like
+  `FITMEN` (`interactive="1"` in the analysis profile XML) genuinely require a
+  human to act in the desktop client, so a `2dsa`-scenario run will always end at
+  `WAIT` there. `--expect-status` (default `FINISHED`) accepts `WAIT`/`FAILED`
+  as valid pass conditions for scenarios that are expected to land there.
+- `--cleanup` (opt-in, `--run` only): after the watch ends regardless of outcome,
+  deletes the `autoflow`/`analysisprofile`/`autoflowAnalysis` rows that `--run`
+  itself created. Never applies to `--watch` (which targets a row it didn't
+  create) and never fires automatically on `WAIT`, since a waiting request can be
+  a real one someone still wants to finish by hand. Without `--cleanup`, prints
+  the equivalent `DELETE` statements instead.
 - `--fake-sbatch fail-always|fail-once` (opt-in, gated behind
   `--yes-i-know-this-restarts-submitctl`): writes a fake `sbatch` into `test_bin/`,
   restarts `submitctl.php` via the existing `services.php restart` with that dir
@@ -106,10 +126,23 @@ argv-parsing + `utility.php` convention.
   afterward. `test_bin/sbatch` and `test_bin/state/` are gitignored (regenerated each
   run); `test_bin/` itself is tracked so the directory exists.
 
+## Status
+
+- 2026-06-23: `--check` validated live on uslimstest; found `elog.txt` (0644,
+  owner-writable by `us3` but not by `apache`) vs `elog2.txt` (0666, writable by
+  both) — an inconsistency the original dir-only/`is_writable()` check would have
+  missed entirely.
+- 2026-06-23: `--run --scenario 2dsa` validated live on uslimstest end-to-end
+  through real `sbatch` submission (job 280) and `SUBMITTED` status, with all
+  logs correctly interleaved.
+- Not yet validated live: `--fake-sbatch fail-always`/`fail-once`, `--cleanup`,
+  non-2dsa scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
+
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain
-  request end-to-end, confirm it traces every status transition through to
-  `FINISHED` and exits 0.
+  request end-to-end, confirm it traces every status transition through to `WAIT`
+  on `FITMEN` (the expected stopping point for this scenario) and exits 0 with
+  `--expect-status WAIT`.
 - Run with `--fake-sbatch fail-always`, confirm it traces through to `FAILED` with
   the expected `ERROR:`-derived `statusMsg`, exits non-zero, and that `scancel`
   logic in `submitctl.php` is not erroneously triggered (no real job was ever
@@ -117,3 +150,6 @@ argv-parsing + `utility.php` convention.
 - Run with `--fake-sbatch fail-once`, confirm the retry/backoff path in
   `submit_local.php::attemptSubmit()` is exercised and the job still ultimately
   succeeds.
+- Run with `--cleanup`, confirm the `autoflow`/`analysisprofile`/`autoflowAnalysis`
+  rows are actually removed; run without it, confirm the printed `DELETE`
+  statements are correct and runnable as-is.

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -174,9 +174,26 @@ argv-parsing + `utility.php` convention.
   after the `su`-restart fix above — the privilege fix surfaced a pre-existing
   ownership mismatch that used to be masked. Fixed by `chown`ing `test_bin/` and
   `test_bin/state/` to `--expected-user` whenever `write_fake_sbatch()` runs.
-- Not yet validated live: `--fake-sbatch fail-always`/`fail-once` (retry pending
-  after the chown fix), non-2dsa scenarios (`pcsa`, `pcsa-onechannel`,
-  `mc-cluster`, `cg`).
+- 2026-06-24: root-caused and fixed a real, previously-undiscovered production bug
+  surfaced by `--fake-sbatch fail-once` (after the chown fix above): `sbatch`
+  attempt 1 failed as injected, but attempts 2-4 all genuinely succeeded on the
+  real cluster (three separate, real, duplicate jobs: 285/286/287) and were still
+  misjudged as failures, ending the whole submission in `FAILED`. Root cause:
+  `us3lims_common/class/submit_local.php`'s `attemptSubmit()` calls `exec($cmd,
+  $output, $status)` repeatedly using the same `$output` array; PHP's `exec()`
+  appends to `$output` rather than replacing it, so `parseSubmitResult()`'s check
+  of `$output[0]` stayed permanently stuck on attempt 1's failure text. Filed as
+  ehb54/ultrascan-tickets#931, fixed on branch `ehb54-issue-931` (PR
+  ehb54/us3lims_common#22) by resetting `$output = array();` at the top of each
+  retry iteration.
+- 2026-06-24: fix validated live on uslimstest via `--fake-sbatch fail-once`:
+  attempt 1 failed as injected, attempt 2 succeeded for real (job 288) and was
+  recognized immediately — no attempts 3/4, no duplicate jobs. `2DSA` then
+  `2DSA_FM` both completed normally, request correctly stopped at `WAIT` on
+  `FITMEN`, `RESULT: PASS`, `--cleanup` removed the test rows. PR #22 confirmed
+  fixing the bug as designed.
+- Not yet validated live: `--fake-sbatch fail-always`, non-2dsa scenarios
+  (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -240,9 +240,14 @@ argv-parsing + `utility.php` convention.
   reach a real `FINISHED`. Fixed by having `watch_request()` check
   `autoflowAnalysisHistory` for the row when it disappears from
   `autoflowAnalysis`, before concluding FAIL - cleanup (already ID-capture
-  based, see above) is unaffected. Not yet re-verified live after this fix.
-- Not yet validated live: `mc-cluster`, `cg` scenarios; re-verification of the
-  `pcsa`/`pcsa-onechannel` FINISHED-detection fix above.
+  based, see above) is unaffected.
+- 2026-06-24: fix verified live for both `pcsa` and `pcsa-onechannel`: each
+  correctly logged `[watch] requestID ... found archived in
+  autoflowAnalysisHistory with status=FINISHED ...` and `RESULT: PASS (status
+  matches expected 'FINISHED')`, with `--cleanup` removing the test rows. Both
+  PCSA scenarios are now fully validated live, success-path and
+  FINISHED-detection alike.
+- Not yet validated live: `mc-cluster`, `cg` scenarios.
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -117,11 +117,17 @@ argv-parsing + `utility.php` convention.
   `WAIT` there. `--expect-status` (default `FINISHED`) accepts `WAIT`/`FAILED`
   as valid pass conditions for scenarios that are expected to land there.
 - `--cleanup` (opt-in, `--run` only): after the watch ends regardless of outcome,
-  deletes the `autoflow`/`analysisprofile`/`autoflowAnalysis` rows that `--run`
-  itself created. Never applies to `--watch` (which targets a row it didn't
-  create) and never fires automatically on `WAIT`, since a waiting request can be
-  a real one someone still wants to finish by hand. Without `--cleanup`, prints
-  the equivalent `DELETE` statements instead.
+  deletes the `autoflow`/`analysisprofile`/`autoflowAnalysis`/
+  `autoflowAnalysisHistory` rows that `--run` itself created. Never applies to
+  `--watch` (which targets a row it didn't create) and never fires automatically
+  on `WAIT`, since a waiting request can be a real one someone still wants to
+  finish by hand. Without `--cleanup`, prints the equivalent `DELETE` statements
+  instead. `autoflowID`/`aprofileGUID` are captured by `watch_request()` from the
+  last row it actually saw while polling, not re-looked-up at cleanup time -
+  `submitctl.php` archives `FINISHED`/`FAILED` rows into
+  `autoflowAnalysisHistory` and deletes them from `autoflowAnalysis` on its very
+  next poll tick (submitctl.php:380-409), so a fresh lookup after the watch ends
+  can already be too late.
 - `--fake-sbatch fail-always|fail-once` (opt-in, gated behind
   `--yes-i-know-this-restarts-submitctl`): writes a fake `sbatch` into `test_bin/`,
   restarts `submitctl.php` via the existing `services.php restart` with that dir
@@ -192,8 +198,21 @@ argv-parsing + `utility.php` convention.
   `2DSA_FM` both completed normally, request correctly stopped at `WAIT` on
   `FITMEN`, `RESULT: PASS`, `--cleanup` removed the test rows. PR #22 confirmed
   fixing the bug as designed.
-- Not yet validated live: `--fake-sbatch fail-always`, non-2dsa scenarios
-  (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
+- 2026-06-24: `--fake-sbatch fail-always --expect-status FAILED` validated live:
+  all 4 attempts (initial + 3 retries) failed as injected, no real job was ever
+  submitted, `submitctl.php`'s `ERROR:`-detection correctly set `FAILED`,
+  `RESULT: PASS`. Surfaced a real cleanup gap: `--cleanup` reported
+  `requestID ... not found (already removed?)` because `submitctl.php` had
+  already archived the `FAILED` row into `autoflowAnalysisHistory` and deleted
+  it from `autoflowAnalysis` (its normal behavior, submitctl.php:380-409) before
+  `cleanup_request()`'s fresh lookup ran - leaving the matching `autoflow`/
+  `analysisprofile` rows orphaned. Fixed by having `watch_request()` capture
+  `autoflowID`/`aprofileGUID` from the last row it actually polled (kept even if
+  the row later disappears) and passing those straight into `cleanup_request()`,
+  which now also deletes from `autoflowAnalysisHistory`. Not yet re-verified
+  live after this fix.
+- Not yet validated live: non-2dsa scenarios (`pcsa`, `pcsa-onechannel`,
+  `mc-cluster`, `cg`).
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -167,8 +167,16 @@ argv-parsing + `utility.php` convention.
   script rather than preserving the daemon's real owner — fixed by routing both
   restarts through `su -s /bin/bash -c ... $expected_user` instead of running
   `services.php restart` directly from the harness's own process.
-- Not yet validated live: `--fake-sbatch fail-always`/`fail-once` (about to be
-  tested), non-2dsa scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
+- 2026-06-23: first live `--fake-sbatch fail-once` attempt failed correctly-but-
+  for-the-wrong-reason: the fake `sbatch`'s counter-file write hit "Permission
+  denied" because `test_bin/state/` was created by the (often root) user running
+  this harness, while the script itself now correctly runs as `--expected-user`
+  after the `su`-restart fix above — the privilege fix surfaced a pre-existing
+  ownership mismatch that used to be masked. Fixed by `chown`ing `test_bin/` and
+  `test_bin/state/` to `--expected-user` whenever `write_fake_sbatch()` runs.
+- Not yet validated live: `--fake-sbatch fail-always`/`fail-once` (retry pending
+  after the chown fix), non-2dsa scenarios (`pcsa`, `pcsa-onechannel`,
+  `mc-cluster`, `cg`).
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -247,7 +247,17 @@ argv-parsing + `utility.php` convention.
   matches expected 'FINISHED')`, with `--cleanup` removing the test rows. Both
   PCSA scenarios are now fully validated live, success-path and
   FINISHED-detection alike.
-- Not yet validated live: `mc-cluster`, `cg` scenarios.
+- 2026-06-24: `--scenario cg` failed immediately - `makeafrequest2DSA-CG.php`
+  takes a required 4th positional arg, `customgridname`, looked up against
+  `<db>.model.description` (an existing custom 2DSA grid previously saved via
+  the "Setup 2DSA Custom Grid" UI) - something the harness has no way to
+  invent on its own. Fixed by adding a `--customgrid <name>` flag, required
+  (and only used) for `--scenario cg`; the harness errors out up front with a
+  clear message if it's missing rather than failing inside
+  `makeafrequest2DSA-CG.php`. Not yet re-tested live with a real
+  `--customgrid` value.
+- Not yet validated live: `mc-cluster` scenario; `cg` scenario with a real
+  `--customgrid` value.
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -131,10 +131,20 @@ argv-parsing + `utility.php` convention.
 - 2026-06-23: `--check` validated live on uslimstest; found `elog.txt` (0644,
   owner-writable by `us3` but not by `apache`) vs `elog2.txt` (0666, writable by
   both) — an inconsistency the original dir-only/`is_writable()` check would have
-  missed entirely.
+  missed entirely. Initially misread as a real gap because the default
+  `--web-user apache` was wrong for this deployment (httpd workers here actually
+  run as `us3`, per `ps -ef`) — fixed by auto-detecting the real non-root
+  httpd/apache2/nginx/php-fpm process owner instead of hardcoding `apache`.
 - 2026-06-23: `--run --scenario 2dsa` validated live on uslimstest end-to-end
   through real `sbatch` submission (job 280) and `SUBMITTED` status, with all
-  logs correctly interleaved.
+  logs correctly interleaved. A later `--run` attempt failed with `mkdir`/`cp`
+  status 127 errors; root-caused to `/bin/mkdir`/`/bin/cp` having been
+  overwritten by an accidental terminal paste (confirmed unrelated to this
+  harness or any gridctl/common code) — resolved via `yum reinstall coreutils`.
+- Reproduced the same `mkdir`/`cp` failure independently via the actual browser
+  submission UI (no harness involved), which is what confirmed it was an OS-level
+  binary corruption issue rather than anything in this tool or in
+  `submit_local.php`.
 - Not yet validated live: `--fake-sbatch fail-always`/`fail-once`, `--cleanup`,
   non-2dsa scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
 

--- a/plans/autoflow-test-harness.md
+++ b/plans/autoflow-test-harness.md
@@ -145,8 +145,17 @@ argv-parsing + `utility.php` convention.
   submission UI (no harness involved), which is what confirmed it was an OS-level
   binary corruption issue rather than anything in this tool or in
   `submit_local.php`.
-- Not yet validated live: `--fake-sbatch fail-always`/`fail-once`, `--cleanup`,
-  non-2dsa scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
+- 2026-06-23: after the `coreutils` reinstall, `--run --scenario 2dsa --expect-status
+  WAIT --cleanup` validated fully live end-to-end: `2DSA` and `2DSA_FM` both ran for
+  real on the grid (`COMPLETE`, with real `maxrss`/runtime stats) and `submitctl.php`
+  auto-advanced through both stages while the harness watched/tailed every log; it
+  then correctly stopped at `WAIT` on `FITMEN` (reported as expected, not a hang),
+  `RESULT: PASS` against `--expect-status WAIT`, and `--cleanup` removed the
+  `autoflow`/`analysisprofile`/`autoflowAnalysis` rows it created. Full happy path
+  (`--check`, multi-stage `--run`, `WAIT`-awareness, `--cleanup`) confirmed working
+  together.
+- Not yet validated live: `--fake-sbatch fail-always`/`fail-once`, non-2dsa
+  scenarios (`pcsa`, `pcsa-onechannel`, `mc-cluster`, `cg`).
 
 ## Verification
 - Run harness against a real GMP host for a normal `makeafrequest.php` 2DSA-chain

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -39,9 +39,10 @@ Common options
 
 --help                        : print this information and exit
 --db                  name    : (required) lims database name, e.g. uslims3_Demo
---gridctl-dir         path    : (required for --run) path to a checked-out
-                                 us3lims_gridctl repo containing autoflow_util/,
-                                 submitctl.php, services.php
+--gridctl-dir         path    : path to the deployed us3lims_gridctl tree
+                                 containing autoflow_util/, submitctl.php,
+                                 services.php (default: ~us3/lims/bin, where
+                                 it's normally deployed)
 --expected-user       name    : username daemons/files are expected to run/be
                                  owned as (default: us3)
 --web-user            name    : username the web server runs as, which also
@@ -244,10 +245,6 @@ if ( !$db ) {
     error_exit( "ERROR: --db must be specified\n---\n$notes" );
 }
 
-if ( $mode == "run" && !$gridctl_dir ) {
-    error_exit( "ERROR: --run requires --gridctl-dir\n---\n$notes" );
-}
-
 if ( $mode == "run" && ( !$invid || !$rawid ) ) {
     error_exit( "ERROR: --run requires --invid and --rawid\n---\n$notes" );
 }
@@ -271,6 +268,14 @@ if ( !is_dir( $us3bin ) ) {
     error_exit( "ERROR: could not resolve ~us3/lims/bin (got '$us3bin') - is this tool running on a us3lims host?" );
 }
 include "$us3bin/listen-config.php";
+
+if ( !$gridctl_dir ) {
+    $gridctl_dir = $us3bin;
+}
+
+if ( $mode == "run" && !is_dir( "$gridctl_dir/autoflow_util" ) ) {
+    error_exit( "ERROR: '$gridctl_dir/autoflow_util' not found - pass --gridctl-dir if us3lims_gridctl isn't deployed at ~us3/lims/bin" );
+}
 
 $test_bin_dir   = __DIR__ . "/test_bin";
 $test_state_dir = "$test_bin_dir/state";

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -47,7 +47,10 @@ Common options
                                  owned as (default: us3)
 --web-user            name    : username the web server runs as, which also
                                  writes some of these log files via the
-                                 browser-triggered submission flow (default: apache)
+                                 browser-triggered submission flow. Default:
+                                 auto-detected from the running httpd/apache2/
+                                 nginx/php-fpm worker process owner (falls back
+                                 to "apache" if that can't be determined)
 --timeout             secs    : max seconds to watch before giving up (default: 600)
 --poll-interval       secs    : seconds between DB/log polls (default: 5)
 
@@ -113,6 +116,7 @@ $reqid            = false;
 $fake_sbatch      = "succeed";
 $confirm_restart  = false;
 $cleanup          = false;
+$web_user_explicit = false;
 
 $scenario_scripts = [
     "2dsa"             => "makeafrequest.php",
@@ -166,6 +170,7 @@ while ( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
             array_shift( $u_argv );
             if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
             $web_user = array_shift( $u_argv );
+            $web_user_explicit = true;
             break;
         }
         case "--timeout": {
@@ -289,6 +294,20 @@ if ( !$gridctl_dir ) {
 
 if ( $mode == "run" && !is_dir( "$gridctl_dir/autoflow_util" ) ) {
     error_exit( "ERROR: '$gridctl_dir/autoflow_util' not found - pass --gridctl-dir if us3lims_gridctl isn't deployed at ~us3/lims/bin" );
+}
+
+# Web server worker processes aren't always actually owned by a user named
+# "apache" (e.g. some deployments run httpd workers as the lims user itself) -
+# detect the real non-root owner of the running web server process and use
+# that as the default unless --web-user was explicitly given.
+if ( !$web_user_explicit ) {
+    $detected = trim( run_cmd(
+        "ps -eo user,comm 2>/dev/null | awk '\$2 ~ /^(httpd|apache2|nginx|php-fpm)\$/ && \$1 != \"root\" {print \$1; exit}'",
+        false
+    ) );
+    if ( $detected !== "" ) {
+        $web_user = $detected;
+    }
 }
 
 $test_bin_dir   = __DIR__ . "/test_bin";

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -537,6 +537,22 @@ function fetch_autoflow_row( $h, $db, $reqid ) {
     return mysqli_fetch_assoc( $res );
 }
 
+# On a successful finish, submitctl.php sets autoflowAnalysis.status='FINISHED'
+# and archives the row into autoflowAnalysisHistory (deleting it from
+# autoflowAnalysis) in the very same poll tick (submitctl.php:349-409) - there is
+# no stable window where a poller can observe status=FINISHED in autoflowAnalysis
+# itself. (FAILED differs: submitone.php's fail_job() writes FAILED
+# asynchronously, well before submitctl.php's next poll cycle archives it, so
+# there IS a window there.) So when a row vanishes from autoflowAnalysis,
+# check autoflowAnalysisHistory before assuming it failed/hung.
+function fetch_autoflow_history_row( $h, $db, $reqid ) {
+    $res = mysqli_query( $h, "SELECT requestID, status, statusMsg, statusJson, updateTime, autoflowID, aprofileGUID FROM ${db}.autoflowAnalysisHistory WHERE requestID=$reqid" );
+    if ( !$res || !$res->num_rows ) {
+        return false;
+    }
+    return mysqli_fetch_assoc( $res );
+}
+
 # Removes the autoflow/analysisprofile/autoflowAnalysis(History) rows created
 # by a --run invocation, regardless of how the watch ended (FINISHED/FAILED/
 # WAIT/timeout) - they're synthetic test data either way. Opt-in only: a WAIT
@@ -599,7 +615,14 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
     while ( true ) {
         $row = fetch_autoflow_row( $h, $db, $reqid );
         if ( !$row ) {
-            echo timestamp() . "[watch] requestID $reqid no longer found\n";
+            $history_row = fetch_autoflow_history_row( $h, $db, $reqid );
+            if ( $history_row ) {
+                echo timestamp() . "[watch] requestID $reqid no longer in autoflowAnalysis - found archived in autoflowAnalysisHistory with status={$history_row['status']} (this is the normal outcome of a successful finish, not a hang)\n";
+                $final = $history_row;
+                $last_known = $history_row;
+            } else {
+                echo timestamp() . "[watch] requestID $reqid no longer found (not in autoflowAnalysis or autoflowAnalysisHistory)\n";
+            }
             break;
         }
         $last_known = $row;

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -44,6 +44,9 @@ Common options
                                  submitctl.php, services.php
 --expected-user       name    : username daemons/files are expected to run/be
                                  owned as (default: us3)
+--web-user            name    : username the web server runs as, which also
+                                 writes some of these log files via the
+                                 browser-triggered submission flow (default: apache)
 --timeout             secs    : max seconds to watch before giving up (default: 600)
 --poll-interval       secs    : seconds between DB/log polls (default: 5)
 
@@ -90,6 +93,7 @@ $mode             = "check";
 $db               = false;
 $gridctl_dir      = false;
 $expected_user    = "us3";
+$web_user         = "apache";
 $timeout          = 600;
 $poll_interval    = 5;
 $invid            = false;
@@ -146,6 +150,12 @@ while ( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
             array_shift( $u_argv );
             if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
             $expected_user = array_shift( $u_argv );
+            break;
+        }
+        case "--web-user": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $web_user = array_shift( $u_argv );
             break;
         }
         case "--timeout": {
@@ -303,19 +313,59 @@ function process_owner( $pid ) {
     return $owner ?: false;
 }
 
+function user_groups( $user ) {
+    static $cache = [];
+    if ( array_key_exists( $user, $cache ) ) {
+        return $cache[ $user ];
+    }
+    $groups = explode( " ", trim( run_cmd( "id -nG " . escapeshellarg( $user ) . " 2>/dev/null || true", false ) ) );
+    $cache[ $user ] = array_filter( $groups, function( $g ) { return $g !== ""; } );
+    return $cache[ $user ];
+}
+
+# Determine whether $expected_user can write $path based on the file's own
+# owner/group/permission bits - NOT PHP's is_writable(), which reflects the
+# privileges of whatever user is running *this* check (often root) and would
+# silently report "writable" even when the real daemon user could not write.
 function path_owner_writable( $path, $expected_user ) {
     if ( !file_exists( $path ) ) {
         return [ "exists" => false ];
     }
-    $stat   = stat( $path );
-    $ownerinfo = posix_getpwuid( $stat[ 'uid' ] );
-    $owner  = $ownerinfo ? $ownerinfo[ 'name' ] : (string) $stat[ 'uid' ];
+    $stat       = stat( $path );
+    $ownerinfo  = posix_getpwuid( $stat[ 'uid' ] );
+    $groupinfo  = posix_getgrgid( $stat[ 'gid' ] );
+    $owner      = $ownerinfo ? $ownerinfo[ 'name' ] : (string) $stat[ 'uid' ];
+    $group      = $groupinfo ? $groupinfo[ 'name' ] : (string) $stat[ 'gid' ];
+    $perm_octal = fileperms( $path ) & 0777;
+
+    $owner_w_bit = (bool) ( $perm_octal & 0200 );
+    $group_w_bit = (bool) ( $perm_octal & 0020 );
+    $other_w_bit = (bool) ( $perm_octal & 0002 );
+
+    $owner_matches = $owner === $expected_user;
+    $in_group      = in_array( $group, user_groups( $expected_user ), true );
+
+    $effective_writable =
+        ( $owner_matches && $owner_w_bit )
+        || ( $in_group && $group_w_bit )
+        || $other_w_bit;
+
+    $reason = $other_w_bit
+        ? "other-writable"
+        : ( ( $in_group && $group_w_bit )
+            ? "group-writable, $expected_user in group $group"
+            : ( ( $owner_matches && $owner_w_bit )
+                ? "owner-writable"
+                : "NOT writable by $expected_user (owner=$owner group=$group, $expected_user " . ( $in_group ? "is" : "is NOT" ) . " in group $group)" ) );
+
     return [
-        "exists"        => true,
-        "owner"         => $owner,
-        "owner_matches" => $owner === $expected_user,
-        "writable"      => is_writable( $path ),
-        "perms"         => substr( sprintf( '%o', fileperms( $path ) ), -4 ),
+        "exists"              => true,
+        "owner"               => $owner,
+        "group"               => $group,
+        "owner_matches"       => $owner_matches,
+        "effective_writable"  => $effective_writable,
+        "reason"              => $reason,
+        "perms"               => sprintf( '%04o', $perm_octal ),
     ];
 }
 
@@ -357,7 +407,7 @@ function tail_state_poll( &$state ) {
 # --check : read-only validation
 ####################################################################
 
-function run_check( $db, $expected_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin ) {
+function run_check( $db, $expected_user, $web_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin ) {
     headerline( "autoflow pipeline health check" );
 
     $services_php = "$us3bin/services.php";
@@ -390,24 +440,35 @@ function run_check( $db, $expected_user, $lock_dir, $home, $submit_log, $udp_log
              " expected=$expected_user " . ( $ok ? "OK" : "** MISMATCH/PROBLEM **" ) . "\n";
     }
 
-    echo "\nWritable paths (expected owner/writer: $expected_user):\n";
+    echo "\nWritable paths/files:\n";
+    echo "(checking both the containing directory - for new file creation - and the file itself if it already exists,\n";
+    echo " using the file's actual owner/group/permission bits, not is_writable(), so this is accurate even run as root.\n";
+    echo " Paths only ever written by the submitctl/submitone daemons are checked against --expected-user ($expected_user,\n";
+    echo " groups: " . implode( ",", user_groups( $expected_user ) ) . "). elog.txt/elog2.txt can ALSO be written directly\n";
+    echo " by browser-triggered submissions running as --web-user ($web_user, groups: " . implode( ",", user_groups( $web_user ) ) . "),\n";
+    echo " so those are checked against both.)\n";
     $paths = [
-        "lock_dir"        => $lock_dir,
-        "submit.log dir"  => dirname( $submit_log ),
-        "udp.log dir"     => dirname( $udp_log ),
-        "dump dir"        => $dump_dir,
-        "elog.txt dir"    => dirname( $elog_file ),
-        "elog2.txt dir"   => dirname( $elog2_file ),
+        "lock_dir"       => [ "users" => [ $expected_user ],             "candidates" => [ $lock_dir ] ],
+        "submit.log"     => [ "users" => [ $expected_user ],             "candidates" => [ dirname( $submit_log ), $submit_log ] ],
+        "udp.log"        => [ "users" => [ $expected_user ],             "candidates" => [ dirname( $udp_log ), $udp_log ] ],
+        "dump dir"       => [ "users" => [ $expected_user ],             "candidates" => [ $dump_dir ] ],
+        "elog.txt"       => [ "users" => [ $expected_user, $web_user ],  "candidates" => [ dirname( $elog_file ), $elog_file ] ],
+        "elog2.txt"      => [ "users" => [ $expected_user, $web_user ],  "candidates" => [ dirname( $elog2_file ), $elog2_file ] ],
     ];
-    foreach ( $paths as $label => $path ) {
-        $info = path_owner_writable( $path, $expected_user );
-        if ( !$info[ "exists" ] ) {
-            echo "  [$label] $path : DOES NOT EXIST\n";
-            continue;
+    foreach ( $paths as $label => $spec ) {
+        foreach ( $spec[ "candidates" ] as $path ) {
+            $kind = is_dir( $path ) ? "dir " : "file";
+            foreach ( $spec[ "users" ] as $for_user ) {
+                $info = path_owner_writable( $path, $for_user );
+                if ( !$info[ "exists" ] ) {
+                    echo "  [$label] $kind $path : DOES NOT EXIST\n";
+                    continue 2; # no point checking a 2nd user against a nonexistent path
+                }
+                echo "  [$label] $kind $path : owner={$info['owner']} group={$info['group']} perms={$info['perms']} writable-by-$for_user=" .
+                     ( $info[ "effective_writable" ] ? "yes" : "** NO **" ) .
+                     " (" . $info[ "reason" ] . ")\n";
+            }
         }
-        echo "  [$label] $path : owner={$info['owner']} perms={$info['perms']} writable=" .
-             ( $info[ "writable" ] ? "yes" : "NO" ) .
-             ( $info[ "owner_matches" ] ? "" : "  ** owner mismatch, expected $expected_user **" ) . "\n";
     }
 
     echo "\nStale autoflowAnalysis rows (status not FINISHED/FAILED, updateTime > 1 hour old):\n";
@@ -529,7 +590,7 @@ function restart_submitctl_with_path( $gridctl_dir, $prepend_path ) {
 switch ( $mode ) {
 
     case "check": {
-        run_check( $db, $expected_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin );
+        run_check( $db, $expected_user, $web_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin );
         exit;
     }
 

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -64,7 +64,15 @@ Common options
 --expect-status       status  : if given, harness exits 0 only if the request
                                  ends at this status instead of the default
                                  FINISHED (e.g. --expect-status FAILED for a
-                                 deliberately-faulted run)
+                                 deliberately-faulted run, or WAIT for a
+                                 scenario that includes an interactive stage
+                                 like FITMEN)
+--cleanup                     : opt-in. After the watch ends (FINISHED, FAILED,
+                                 WAIT, or timeout), delete the autoflow/
+                                 analysisprofile/autoflowAnalysis rows this
+                                 --run created. Without --cleanup, the
+                                 equivalent DELETE statements are printed
+                                 instead so cleanup is still a copy-paste away.
 
 --watch options
 
@@ -104,6 +112,7 @@ $expect_status    = "FINISHED";
 $reqid            = false;
 $fake_sbatch      = "succeed";
 $confirm_restart  = false;
+$cleanup          = false;
 
 $scenario_scripts = [
     "2dsa"             => "makeafrequest.php",
@@ -216,6 +225,11 @@ while ( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
         case "--yes-i-know-this-restarts-submitctl": {
             array_shift( $u_argv );
             $confirm_restart = true;
+            break;
+        }
+        case "--cleanup": {
+            array_shift( $u_argv );
+            $cleanup = true;
             break;
         }
         default: {
@@ -500,6 +514,45 @@ function fetch_autoflow_row( $h, $db, $reqid ) {
     return mysqli_fetch_assoc( $res );
 }
 
+# Removes the autoflow/analysisprofile/autoflowAnalysis rows created by a
+# --run invocation, regardless of how the watch ended (FINISHED/FAILED/WAIT/
+# timeout) - they're synthetic test data either way. Opt-in only: a WAIT row
+# in particular can be a legitimate request a human still wants to finish by
+# hand, so this is never run unless --cleanup was explicitly given. Without
+# --cleanup, prints the equivalent DELETE statements so cleanup is still a
+# one-line copy-paste away.
+function cleanup_request( $db, $reqid, $do_cleanup ) {
+    $h = db_connect_lims();
+    $res = mysqli_query( $h, "SELECT autoflowID, aprofileGUID FROM ${db}.autoflowAnalysis WHERE requestID=$reqid" );
+    $row = $res ? mysqli_fetch_assoc( $res ) : false;
+    if ( !$row ) {
+        echo "[cleanup] requestID $reqid not found (already removed?) - nothing to do\n";
+        return;
+    }
+
+    $aprofileguid_esc = mysqli_real_escape_string( $h, $row[ "aprofileGUID" ] );
+    $autoflowid        = (int) $row[ "autoflowID" ];
+    $deletes = [
+        "DELETE FROM ${db}.autoflowAnalysis WHERE requestID=$reqid",
+        "DELETE FROM ${db}.analysisprofile WHERE aprofileGUID='$aprofileguid_esc'",
+        "DELETE FROM ${db}.autoflow WHERE ID=$autoflowid",
+    ];
+
+    if ( $do_cleanup ) {
+        echo "[cleanup] --cleanup given: removing test data for requestID=$reqid (autoflow ID=$autoflowid, analysisprofile aprofileGUID={$row['aprofileGUID']})\n";
+        foreach ( $deletes as $sql ) {
+            if ( !mysqli_query( $h, $sql ) ) {
+                echo "[cleanup] ERROR running '$sql': " . mysqli_error( $h ) . "\n";
+            }
+        }
+    } else {
+        echo "[cleanup] test data left in place (pass --cleanup to remove it). To clean up manually:\n";
+        foreach ( $deletes as $sql ) {
+            echo "  $sql;\n";
+        }
+    }
+}
+
 function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
     headerline( "watching autoflowAnalysis requestID=$reqid (db=$db)" );
 
@@ -523,6 +576,15 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
         tail_state_poll( $tail_state );
 
         if ( in_array( $row[ "status" ], [ "FINISHED", "FAILED" ] ) ) {
+            $final = $row;
+            break;
+        }
+        if ( strtoupper( $row[ "status" ] ) === "WAIT" ) {
+            $statusJson = json_decode( $row[ "statusJson" ] );
+            $waiting_on = $statusJson && isset( $statusJson->submitted ) ? $statusJson->submitted : "(unknown stage)";
+            echo timestamp() . "[watch] requestID $reqid is WAITing on stage '$waiting_on' - this is expected for interactive\n";
+            echo timestamp() . "[watch] stages (e.g. FITMEN requires a human to run interactive fitting in the desktop client\n";
+            echo timestamp() . "[watch] and post results back). This is NOT a failure or a hang; stopping the watch here.\n";
             $final = $row;
             break;
         }
@@ -647,6 +709,7 @@ switch ( $mode ) {
 
         if ( !$final ) {
             echo "RESULT: requestID $found_reqid disappeared mid-watch - FAIL\n";
+            cleanup_request( $db, $found_reqid, $cleanup );
             exit( 1 );
         }
 
@@ -654,13 +717,13 @@ switch ( $mode ) {
         echo "requestID={$final['requestID']} status={$final['status']} statusMsg={$final['statusMsg']}\n";
         echo "statusJson={$final['statusJson']}\n";
 
-        if ( $final[ "status" ] === $expect_status ) {
-            echo "RESULT: PASS (status matches expected '$expect_status')\n";
-            exit( 0 );
-        } else {
-            echo "RESULT: FAIL (status '{$final['status']}' != expected '$expect_status')\n";
-            exit( 1 );
-        }
+        $passed = strcasecmp( $final[ "status" ], $expect_status ) === 0;
+        echo $passed
+            ? "RESULT: PASS (status matches expected '$expect_status')\n"
+            : "RESULT: FAIL (status '{$final['status']}' != expected '$expect_status')\n";
+
+        cleanup_request( $db, $found_reqid, $cleanup );
+        exit( $passed ? 0 : 1 );
     }
 
     case "watch": {
@@ -677,6 +740,6 @@ switch ( $mode ) {
         }
         headerline( "final result" );
         echo "requestID={$final['requestID']} status={$final['status']} statusMsg={$final['statusMsg']}\n";
-        exit( in_array( $final[ "status" ], [ "FINISHED" ] ) ? 0 : 1 );
+        exit( strcasecmp( $final[ "status" ], $expect_status ) === 0 ? 0 : 1 );
     }
 }

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -1,0 +1,616 @@
+<?php
+
+# uslims_autoflow_test.php
+#
+# Standalone, read-only-by-default debug/monitoring/validation tool for the
+# autoflow GMP submission pipeline (makeafrequest*.php -> submitctl.php ->
+# submitone.php -> us3lims_common's submit_local.php -> sbatch/qsub).
+#
+# This tool never modifies us3lims_gridctl or us3lims_common source. It only:
+#  - reads the database
+#  - tails log files
+#  - inspects running processes & file permissions
+#  - calls existing CLI entry points (makeafrequest*.php, services.php) the
+#    same way a human operator would
+#
+# See ~/.claude/plans/need-to-debug-https-github-com-ehb54-us3-declarative-nebula.md
+# for the design this implements.
+
+$self = __FILE__;
+
+$notes = <<<__EOD
+usage: $self {options} {db_config_file}
+
+Debug/monitor/validate the autoflow submitctl/submitone job submission
+pipeline without modifying any us3lims_gridctl/us3lims_common code.
+
+Modes (pick one; default is --check)
+
+--check                       : read-only validation of the pipeline's health
+                                 (services running? correct user? log/lock dirs
+                                 writable? any stale READY/SUBMITTED rows?)
+--run                         : create a new autoflowAnalysis request via
+                                 makeafrequest*.php, then watch it through to
+                                 FINISHED/FAILED/timeout
+--watch                       : watch (and tail logs for) an existing request,
+                                 requires --reqid
+
+Common options
+
+--help                        : print this information and exit
+--db                  name    : (required) lims database name, e.g. uslims3_Demo
+--gridctl-dir         path    : (required for --run) path to a checked-out
+                                 us3lims_gridctl repo containing autoflow_util/,
+                                 submitctl.php, services.php
+--expected-user       name    : username daemons/files are expected to run/be
+                                 owned as (default: us3)
+--timeout             secs    : max seconds to watch before giving up (default: 600)
+--poll-interval       secs    : seconds between DB/log polls (default: 5)
+
+--run options
+
+--invid               id      : investigator personID to pass to makeafrequest*.php
+--rawid               id      : rawDataID to pass to makeafrequest*.php
+--scenario            name    : which autoflow_util/makeafrequest*.php variant to
+                                 use: 2dsa (default, makeafrequest.php), pcsa
+                                 (makeafrequestPCSA.php), pcsa-onechannel
+                                 (makeafrequestPCSAonechannel.php), mc-cluster
+                                 (makeafrequest2DSA_MC_cluster.php), cg
+                                 (makeafrequest2DSA-CG.php)
+--expect-status       status  : if given, harness exits 0 only if the request
+                                 ends at this status instead of the default
+                                 FINISHED (e.g. --expect-status FAILED for a
+                                 deliberately-faulted run)
+
+--watch options
+
+--reqid               id      : autoflowAnalysis.requestID to watch
+
+Fault injection (opt-in, environment-only, never edits gridctl/common code)
+
+--fake-sbatch         mode    : succeed (default, real sbatch untouched),
+                                 fail-always, or fail-once
+--yes-i-know-this-restarts-submitctl
+                               : required to actually enable --fake-sbatch;
+                                 acknowledges this restarts the live
+                                 submitctl.php daemon (via the existing
+                                 services.php restart) to apply a PATH
+                                 override, affecting any other in-flight jobs
+                                 on a shared system. submitctl.php is restarted
+                                 again with the original PATH once the watch
+                                 ends.
+
+__EOD;
+
+require "utility.php";
+$u_argv = $argv;
+array_shift( $u_argv );
+
+$mode             = "check";
+$db               = false;
+$gridctl_dir      = false;
+$expected_user    = "us3";
+$timeout          = 600;
+$poll_interval    = 5;
+$invid            = false;
+$rawid            = false;
+$scenario         = "2dsa";
+$expect_status    = "FINISHED";
+$reqid            = false;
+$fake_sbatch      = "succeed";
+$confirm_restart  = false;
+
+$scenario_scripts = [
+    "2dsa"             => "makeafrequest.php",
+    "pcsa"             => "makeafrequestPCSA.php",
+    "pcsa-onechannel"  => "makeafrequestPCSAonechannel.php",
+    "mc-cluster"       => "makeafrequest2DSA_MC_cluster.php",
+    "cg"               => "makeafrequest2DSA-CG.php",
+];
+
+while ( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
+    $arg = $u_argv[ 0 ];
+    switch ( $arg ) {
+        case "--help": {
+            echo $notes;
+            exit;
+        }
+        case "--check": {
+            array_shift( $u_argv );
+            $mode = "check";
+            break;
+        }
+        case "--run": {
+            array_shift( $u_argv );
+            $mode = "run";
+            break;
+        }
+        case "--watch": {
+            array_shift( $u_argv );
+            $mode = "watch";
+            break;
+        }
+        case "--db": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $db = array_shift( $u_argv );
+            break;
+        }
+        case "--gridctl-dir": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $gridctl_dir = rtrim( array_shift( $u_argv ), "/" );
+            break;
+        }
+        case "--expected-user": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $expected_user = array_shift( $u_argv );
+            break;
+        }
+        case "--timeout": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $timeout = (int) array_shift( $u_argv );
+            break;
+        }
+        case "--poll-interval": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $poll_interval = (int) array_shift( $u_argv );
+            break;
+        }
+        case "--invid": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $invid = array_shift( $u_argv );
+            break;
+        }
+        case "--rawid": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $rawid = array_shift( $u_argv );
+            break;
+        }
+        case "--scenario": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $scenario = array_shift( $u_argv );
+            if ( !array_key_exists( $scenario, $scenario_scripts ) ) {
+                error_exit( "ERROR: unknown --scenario '$scenario'. Known scenarios: " . implode( ", ", array_keys( $scenario_scripts ) ) );
+            }
+            break;
+        }
+        case "--expect-status": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $expect_status = array_shift( $u_argv );
+            break;
+        }
+        case "--reqid": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $reqid = array_shift( $u_argv );
+            break;
+        }
+        case "--fake-sbatch": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $fake_sbatch = array_shift( $u_argv );
+            if ( !in_array( $fake_sbatch, [ "succeed", "fail-always", "fail-once" ] ) ) {
+                error_exit( "ERROR: unknown --fake-sbatch mode '$fake_sbatch'" );
+            }
+            break;
+        }
+        case "--yes-i-know-this-restarts-submitctl": {
+            array_shift( $u_argv );
+            $confirm_restart = true;
+            break;
+        }
+        default: {
+            error_exit( "\nUnknown option '$arg'\n\n$notes" );
+        }
+    }
+}
+
+$config_file = "db_config.php";
+$use_config_file = count( $u_argv ) ? array_shift( $u_argv ) : $config_file;
+
+if ( count( $u_argv ) ) {
+    echo $notes;
+    exit;
+}
+
+if ( !file_exists( $use_config_file ) ) {
+    error_exit(
+        "$self:\n$use_config_file does not exist\n\nto fix:\n\ncp ${config_file}.template $use_config_file\nand edit with appropriate values\n"
+    );
+}
+
+file_perms_must_be( $use_config_file );
+require $use_config_file;
+
+if ( !$db ) {
+    error_exit( "ERROR: --db must be specified\n---\n$notes" );
+}
+
+if ( $mode == "run" && !$gridctl_dir ) {
+    error_exit( "ERROR: --run requires --gridctl-dir\n---\n$notes" );
+}
+
+if ( $mode == "run" && ( !$invid || !$rawid ) ) {
+    error_exit( "ERROR: --run requires --invid and --rawid\n---\n$notes" );
+}
+
+if ( $mode == "watch" && !$reqid ) {
+    error_exit( "ERROR: --watch requires --reqid\n---\n$notes" );
+}
+
+if ( $fake_sbatch != "succeed" && !$confirm_restart ) {
+    error_exit( "ERROR: --fake-sbatch $fake_sbatch requires --yes-i-know-this-restarts-submitctl" );
+}
+
+####################################################################
+# pull in the SAME config the real daemons use (read-only include,
+# never modified) so paths/credentials always match production exactly
+####################################################################
+
+$us3bin = exec( "ls -d ~us3/lims/bin" );
+$us3home = exec( "ls -d ~us3" );
+if ( !is_dir( $us3bin ) ) {
+    error_exit( "ERROR: could not resolve ~us3/lims/bin (got '$us3bin') - is this tool running on a us3lims host?" );
+}
+include "$us3bin/listen-config.php";
+
+$test_bin_dir   = __DIR__ . "/test_bin";
+$test_state_dir = "$test_bin_dir/state";
+
+$submit_log   = "$home/etc/submit.log";
+$udp_log      = $logfile;                       # from listen-config.php
+$dump_dir     = "$home/etc/submit";
+$elog_file    = "$us3home/lims/etc/elog.txt";
+$elog2_file   = "/home/us3/lims/etc/elog2.txt";  # hardcoded in submit_local.php
+$gridctl_lock = "$lock_dir/submitctl.php.lock";
+
+####################################################################
+# shared helpers
+####################################################################
+
+function db_connect_lims() {
+    global $dbhost, $user, $passwd;
+    $h = mysqli_connect( $dbhost, $user, $passwd );
+    if ( !$h ) {
+        error_exit( "ERROR: could not connect to mysql $dbhost as $user" );
+    }
+    return $h;
+}
+
+function pid_from_lock( $lockfile ) {
+    if ( !file_exists( $lockfile ) ) {
+        return false;
+    }
+    if ( is_link( $lockfile ) ) {
+        return (int) substr( readlink( $lockfile ), 6 );
+    }
+    return (int) trim( file_get_contents( $lockfile ) );
+}
+
+function process_owner( $pid ) {
+    if ( !$pid || !file_exists( "/proc/$pid" ) ) {
+        return false;
+    }
+    $owner = trim( run_cmd( "ps -o user= -p $pid", false ) );
+    return $owner ?: false;
+}
+
+function path_owner_writable( $path, $expected_user ) {
+    if ( !file_exists( $path ) ) {
+        return [ "exists" => false ];
+    }
+    $stat   = stat( $path );
+    $ownerinfo = posix_getpwuid( $stat[ 'uid' ] );
+    $owner  = $ownerinfo ? $ownerinfo[ 'name' ] : (string) $stat[ 'uid' ];
+    return [
+        "exists"        => true,
+        "owner"         => $owner,
+        "owner_matches" => $owner === $expected_user,
+        "writable"      => is_writable( $path ),
+        "perms"         => substr( sprintf( '%o', fileperms( $path ) ), -4 ),
+    ];
+}
+
+function tail_state_init( $files ) {
+    $state = [];
+    foreach ( $files as $label => $path ) {
+        $state[ $label ] = [
+            "path" => $path,
+            "pos"  => file_exists( $path ) ? filesize( $path ) : 0,
+        ];
+    }
+    return $state;
+}
+
+function tail_state_poll( &$state ) {
+    foreach ( $state as $label => &$entry ) {
+        $path = $entry[ "path" ];
+        if ( !file_exists( $path ) ) {
+            continue;
+        }
+        $size = filesize( $path );
+        if ( $size < $entry[ "pos" ] ) {
+            # file was rotated/truncated
+            $entry[ "pos" ] = 0;
+        }
+        if ( $size > $entry[ "pos" ] ) {
+            $fh = fopen( $path, "r" );
+            fseek( $fh, $entry[ "pos" ] );
+            while ( ( $line = fgets( $fh ) ) !== false ) {
+                echo timestamp() . "[$label] " . rtrim( $line ) . "\n";
+            }
+            $entry[ "pos" ] = ftell( $fh );
+            fclose( $fh );
+        }
+    }
+}
+
+####################################################################
+# --check : read-only validation
+####################################################################
+
+function run_check( $db, $expected_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin ) {
+    headerline( "autoflow pipeline health check" );
+
+    $services_php = "$us3bin/services.php";
+    echo "Service status ($services_php status):\n";
+    if ( file_exists( $services_php ) ) {
+        echo run_cmd( "php " . escapeshellarg( $services_php ) . " status 2>&1", false );
+    } else {
+        echo "  ** $services_php not found, skipping **\n";
+    }
+    echo "\n";
+
+    $locks = [
+        "listen"      => "$lock_dir/listen.php.lock",
+        "manage"      => "$lock_dir/manage-us3-pipe.php.lock",
+        "submitctl"   => "$lock_dir/submitctl.php.lock",
+        "esign"       => "$lock_dir/esign.php.lock",
+    ];
+
+    foreach ( $locks as $name => $lockfile ) {
+        $pid   = pid_from_lock( $lockfile );
+        $owner = $pid ? process_owner( $pid ) : false;
+        if ( !$pid ) {
+            echo "  [$name] NOT RUNNING (no lock file or stale)\n";
+            continue;
+        }
+        $alive = file_exists( "/proc/$pid" );
+        $ok    = $alive && $owner === $expected_user;
+        echo "  [$name] pid=$pid alive=" . ( $alive ? "yes" : "NO" ) .
+             " owner=" . ( $owner ?: "?" ) .
+             " expected=$expected_user " . ( $ok ? "OK" : "** MISMATCH/PROBLEM **" ) . "\n";
+    }
+
+    echo "\nWritable paths (expected owner/writer: $expected_user):\n";
+    $paths = [
+        "lock_dir"        => $lock_dir,
+        "submit.log dir"  => dirname( $submit_log ),
+        "udp.log dir"     => dirname( $udp_log ),
+        "dump dir"        => $dump_dir,
+        "elog.txt dir"    => dirname( $elog_file ),
+        "elog2.txt dir"   => dirname( $elog2_file ),
+    ];
+    foreach ( $paths as $label => $path ) {
+        $info = path_owner_writable( $path, $expected_user );
+        if ( !$info[ "exists" ] ) {
+            echo "  [$label] $path : DOES NOT EXIST\n";
+            continue;
+        }
+        echo "  [$label] $path : owner={$info['owner']} perms={$info['perms']} writable=" .
+             ( $info[ "writable" ] ? "yes" : "NO" ) .
+             ( $info[ "owner_matches" ] ? "" : "  ** owner mismatch, expected $expected_user **" ) . "\n";
+    }
+
+    echo "\nStale autoflowAnalysis rows (status not FINISHED/FAILED, updateTime > 1 hour old):\n";
+    $h = db_connect_lims();
+    $res = mysqli_query( $h, "SELECT requestID, status, statusMsg, updateTime FROM ${db}.autoflowAnalysis WHERE status NOT IN ('FINISHED','FAILED') AND updateTime < ( NOW() - INTERVAL 1 HOUR )" );
+    if ( $res && $res->num_rows ) {
+        while ( $row = mysqli_fetch_assoc( $res ) ) {
+            echo "  ** requestID={$row['requestID']} status={$row['status']} updateTime={$row['updateTime']} statusMsg={$row['statusMsg']}\n";
+        }
+    } else {
+        echo "  none found\n";
+    }
+}
+
+####################################################################
+# --run / --watch : drive and/or watch a request through the pipeline
+####################################################################
+
+function fetch_autoflow_row( $h, $db, $reqid ) {
+    $res = mysqli_query( $h, "SELECT requestID, status, statusMsg, statusJson, updateTime FROM ${db}.autoflowAnalysis WHERE requestID=$reqid" );
+    if ( !$res || !$res->num_rows ) {
+        return false;
+    }
+    return mysqli_fetch_assoc( $res );
+}
+
+function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
+    headerline( "watching autoflowAnalysis requestID=$reqid (db=$db)" );
+
+    $h = db_connect_lims();
+    $tail_state = tail_state_init( $log_files );
+    $last_status_json = null;
+    $start = time();
+    $final = false;
+
+    while ( true ) {
+        $row = fetch_autoflow_row( $h, $db, $reqid );
+        if ( !$row ) {
+            echo timestamp() . "[watch] requestID $reqid no longer found\n";
+            break;
+        }
+        if ( $row[ "statusJson" ] !== $last_status_json ) {
+            echo timestamp() . "[watch] status={$row['status']} statusMsg={$row['statusMsg']} statusJson={$row['statusJson']}\n";
+            $last_status_json = $row[ "statusJson" ];
+        }
+
+        tail_state_poll( $tail_state );
+
+        if ( in_array( $row[ "status" ], [ "FINISHED", "FAILED" ] ) ) {
+            $final = $row;
+            break;
+        }
+        if ( time() - $start > $timeout ) {
+            echo timestamp() . "[watch] timeout after ${timeout}s, last status={$row['status']}\n";
+            $final = $row;
+            break;
+        }
+        sleep( $poll_interval );
+    }
+
+    # final drain in case anything landed between the last poll and exit
+    tail_state_poll( $tail_state );
+    return $final;
+}
+
+####################################################################
+# fault injection helpers
+####################################################################
+
+function write_fake_sbatch( $test_bin_dir, $test_state_dir, $mode ) {
+    if ( !is_dir( $test_bin_dir ) ) {
+        mkdir( $test_bin_dir, 0755, true );
+    }
+    if ( !is_dir( $test_state_dir ) ) {
+        mkdir( $test_state_dir, 0755, true );
+    }
+    $counter_file = "$test_state_dir/sbatch_fail_once_counter";
+    if ( file_exists( $counter_file ) ) {
+        unlink( $counter_file );
+    }
+
+    $real_sbatch = trim( run_cmd( "command -v sbatch || true", false ) );
+
+    $script = "#!/bin/bash\n";
+    $script .= "# generated by uslims_autoflow_test.php --fake-sbatch=$mode - safe to delete\n";
+    if ( $mode === "fail-always" ) {
+        $script .= "echo 'sbatch: error: Socket timed out on send/recv operation (fake-sbatch fail-always)' >&2\n";
+        $script .= "exit 1\n";
+    } elseif ( $mode === "fail-once" ) {
+        $script .= "COUNTER_FILE='$counter_file'\n";
+        $script .= "count=0\n";
+        $script .= "if [ -f \"\$COUNTER_FILE\" ]; then count=\$(cat \"\$COUNTER_FILE\"); fi\n";
+        $script .= "count=\$((count+1))\n";
+        $script .= "echo \$count > \"\$COUNTER_FILE\"\n";
+        $script .= "if [ \"\$count\" -le 1 ]; then\n";
+        $script .= "  echo 'sbatch: error: Socket timed out on send/recv operation (fake-sbatch fail-once, attempt '\$count')' >&2\n";
+        $script .= "  exit 1\n";
+        $script .= "fi\n";
+        $script .= "exec '$real_sbatch' \"\$@\"\n";
+    } else { # succeed - thin passthrough to the real sbatch
+        $script .= "exec '$real_sbatch' \"\$@\"\n";
+    }
+
+    $path = "$test_bin_dir/sbatch";
+    file_put_contents( $path, $script );
+    chmod( $path, 0755 );
+    return $path;
+}
+
+function restart_submitctl_with_path( $gridctl_dir, $prepend_path ) {
+    $path_env = $prepend_path ? "PATH=$prepend_path:\$PATH " : "";
+    echo run_cmd( "cd " . escapeshellarg( $gridctl_dir ) . " && $path_env php services.php restart 2>&1", false );
+}
+
+####################################################################
+# main
+####################################################################
+
+switch ( $mode ) {
+
+    case "check": {
+        run_check( $db, $expected_user, $lock_dir, $home, $submit_log, $udp_log, $dump_dir, $elog_file, $elog2_file, $us3bin );
+        exit;
+    }
+
+    case "run": {
+        if ( !is_dir( $gridctl_dir ) ) {
+            error_exit( "ERROR: --gridctl-dir '$gridctl_dir' is not a directory" );
+        }
+        $script = $gridctl_dir . "/autoflow_util/" . $scenario_scripts[ $scenario ];
+        if ( !file_exists( $script ) ) {
+            error_exit( "ERROR: scenario script not found: $script" );
+        }
+
+        if ( $fake_sbatch != "succeed" ) {
+            echo "*** --fake-sbatch=$fake_sbatch enabled: restarting submitctl.php with a PATH override (this affects ANY in-flight jobs on this system) ***\n";
+            $fake_path = write_fake_sbatch( $test_bin_dir, $test_state_dir, $fake_sbatch );
+            restart_submitctl_with_path( $gridctl_dir, $test_bin_dir );
+        }
+
+        echo "Creating request via " . basename( $script ) . " $db $invid $rawid ...\n";
+        $output = run_cmd( "cd " . escapeshellarg( $gridctl_dir . "/autoflow_util" ) . " && php " . escapeshellarg( basename( $script ) ) . " " . escapeshellarg( $db ) . " " . escapeshellarg( $invid ) . " " . escapeshellarg( $rawid ) . " 2>&1", false, true );
+        foreach ( $output as $line ) {
+            echo "[makeafrequest] $line\n";
+        }
+
+        $found_reqid = false;
+        foreach ( $output as $line ) {
+            if ( preg_match( '/inserted autoflowAnalysis requestID is (\d+)/', $line, $m ) ) {
+                $found_reqid = (int) $m[ 1 ];
+            }
+        }
+        if ( !$found_reqid ) {
+            error_exit( "ERROR: could not determine requestID from makeafrequest output above" );
+        }
+
+        $log_files = [
+            "submit.log" => $submit_log,
+            "udp.log"    => $udp_log,
+            "elog.txt"   => $elog_file,
+            "elog2.txt"  => $elog2_file,
+            "dump"       => "$dump_dir/$db-$found_reqid.txt",
+        ];
+
+        $final = watch_request( $db, $found_reqid, $timeout, $poll_interval, $log_files );
+
+        if ( $fake_sbatch != "succeed" ) {
+            echo "*** restoring submitctl.php to its normal PATH ***\n";
+            restart_submitctl_with_path( $gridctl_dir, false );
+        }
+
+        if ( !$final ) {
+            echo "RESULT: requestID $found_reqid disappeared mid-watch - FAIL\n";
+            exit( 1 );
+        }
+
+        headerline( "final result" );
+        echo "requestID={$final['requestID']} status={$final['status']} statusMsg={$final['statusMsg']}\n";
+        echo "statusJson={$final['statusJson']}\n";
+
+        if ( $final[ "status" ] === $expect_status ) {
+            echo "RESULT: PASS (status matches expected '$expect_status')\n";
+            exit( 0 );
+        } else {
+            echo "RESULT: FAIL (status '{$final['status']}' != expected '$expect_status')\n";
+            exit( 1 );
+        }
+    }
+
+    case "watch": {
+        $log_files = [
+            "submit.log" => $submit_log,
+            "udp.log"    => $udp_log,
+            "elog.txt"   => $elog_file,
+            "elog2.txt"  => $elog2_file,
+            "dump"       => "$dump_dir/$db-$reqid.txt",
+        ];
+        $final = watch_request( $db, $reqid, $timeout, $poll_interval, $log_files );
+        if ( !$final ) {
+            exit( 1 );
+        }
+        headerline( "final result" );
+        echo "requestID={$final['requestID']} status={$final['status']} statusMsg={$final['statusMsg']}\n";
+        exit( in_array( $final[ "status" ], [ "FINISHED" ] ) ? 0 : 1 );
+    }
+}

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -628,13 +628,20 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
 # fault injection helpers
 ####################################################################
 
-function write_fake_sbatch( $test_bin_dir, $test_state_dir, $mode ) {
+function write_fake_sbatch( $test_bin_dir, $test_state_dir, $mode, $expected_user ) {
     if ( !is_dir( $test_bin_dir ) ) {
         mkdir( $test_bin_dir, 0755, true );
     }
     if ( !is_dir( $test_state_dir ) ) {
         mkdir( $test_state_dir, 0755, true );
     }
+    # The fake sbatch script below runs as $expected_user (submitctl.php is
+    # restarted as that user), but these dirs are typically created by
+    # whoever runs this harness (often root) - chown them so $expected_user
+    # can actually write its counter file regardless of who created them.
+    @chown( $test_bin_dir, $expected_user );
+    @chown( $test_state_dir, $expected_user );
+
     $counter_file = "$test_state_dir/sbatch_fail_once_counter";
     if ( file_exists( $counter_file ) ) {
         unlink( $counter_file );
@@ -702,7 +709,7 @@ switch ( $mode ) {
 
         if ( $fake_sbatch != "succeed" ) {
             echo "*** --fake-sbatch=$fake_sbatch enabled: restarting submitctl.php with a PATH override (this affects ANY in-flight jobs on this system) ***\n";
-            $fake_path = write_fake_sbatch( $test_bin_dir, $test_state_dir, $fake_sbatch );
+            $fake_path = write_fake_sbatch( $test_bin_dir, $test_state_dir, $fake_sbatch, $expected_user );
             restart_submitctl_with_path( $gridctl_dir, $test_bin_dir, $expected_user );
         }
 

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -496,7 +496,7 @@ function run_check( $db, $expected_user, $web_user, $lock_dir, $home, $submit_lo
     foreach ( $paths as $label => $spec ) {
         foreach ( $spec[ "candidates" ] as $path ) {
             $kind = is_dir( $path ) ? "dir " : "file";
-            foreach ( $spec[ "users" ] as $for_user ) {
+            foreach ( array_unique( $spec[ "users" ] ) as $for_user ) {
                 $info = path_owner_writable( $path, $for_user );
                 if ( !$info[ "exists" ] ) {
                     echo "  [$label] $kind $path : DOES NOT EXIST\n";

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -63,7 +63,13 @@ Common options
                                  (makeafrequestPCSA.php), pcsa-onechannel
                                  (makeafrequestPCSAonechannel.php), mc-cluster
                                  (makeafrequest2DSA_MC_cluster.php), cg
-                                 (makeafrequest2DSA-CG.php)
+                                 (makeafrequest2DSA-CG.php, requires --customgrid)
+--customgrid          name    : required for --scenario cg. Must match an
+                                 existing description in <db>.model - i.e. a
+                                 custom 2DSA grid already saved on the target
+                                 system via the 'Setup 2DSA Custom Grid' UI.
+                                 The harness cannot invent one; it has to be a
+                                 real model already in the database.
 --expect-status       status  : if given, harness exits 0 only if the request
                                  ends at this status instead of the default
                                  FINISHED (e.g. --expect-status FAILED for a
@@ -121,6 +127,7 @@ $fake_sbatch      = "succeed";
 $confirm_restart  = false;
 $cleanup          = false;
 $web_user_explicit = false;
+$customgrid       = false;
 
 $scenario_scripts = [
     "2dsa"             => "makeafrequest.php",
@@ -208,6 +215,12 @@ while ( count( $u_argv ) && substr( $u_argv[ 0 ], 0, 1 ) == "-" ) {
             if ( !array_key_exists( $scenario, $scenario_scripts ) ) {
                 error_exit( "ERROR: unknown --scenario '$scenario'. Known scenarios: " . implode( ", ", array_keys( $scenario_scripts ) ) );
             }
+            break;
+        }
+        case "--customgrid": {
+            array_shift( $u_argv );
+            if ( !count( $u_argv ) ) { error_exit( "ERROR: option '$arg' requires an argument\n$notes" ); }
+            $customgrid = array_shift( $u_argv );
             break;
         }
         case "--expect-status": {
@@ -741,6 +754,9 @@ switch ( $mode ) {
         if ( !file_exists( $script ) ) {
             error_exit( "ERROR: scenario script not found: $script" );
         }
+        if ( $scenario === "cg" && !$customgrid ) {
+            error_exit( "ERROR: --scenario cg requires --customgrid <name>, matching a description in ${db}.model (an existing custom 2DSA grid saved via the 'Setup 2DSA Custom Grid' UI)" );
+        }
 
         if ( $fake_sbatch != "succeed" ) {
             echo "*** --fake-sbatch=$fake_sbatch enabled: restarting submitctl.php with a PATH override (this affects ANY in-flight jobs on this system) ***\n";
@@ -748,8 +764,17 @@ switch ( $mode ) {
             restart_submitctl_with_path( $gridctl_dir, $test_bin_dir, $expected_user );
         }
 
-        echo "Creating request via " . basename( $script ) . " $db $invid $rawid ...\n";
-        $output = run_cmd( "cd " . escapeshellarg( $gridctl_dir . "/autoflow_util" ) . " && php " . escapeshellarg( basename( $script ) ) . " " . escapeshellarg( $db ) . " " . escapeshellarg( $invid ) . " " . escapeshellarg( $rawid ) . " 2>&1", false, true );
+        $script_args = [ $db, $invid, $rawid ];
+        if ( $scenario === "cg" ) {
+            $script_args[] = $customgrid;
+        }
+        echo "Creating request via " . basename( $script ) . " " . implode( " ", $script_args ) . " ...\n";
+        $cmd = "cd " . escapeshellarg( $gridctl_dir . "/autoflow_util" ) . " && php " . escapeshellarg( basename( $script ) );
+        foreach ( $script_args as $script_arg ) {
+            $cmd .= " " . escapeshellarg( $script_arg );
+        }
+        $cmd .= " 2>&1";
+        $output = run_cmd( $cmd, false, true );
         foreach ( $output as $line ) {
             echo "[makeafrequest] $line\n";
         }

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -62,7 +62,8 @@ Common options
                                  use: 2dsa (default, makeafrequest.php), pcsa
                                  (makeafrequestPCSA.php), pcsa-onechannel
                                  (makeafrequestPCSAonechannel.php), mc-cluster
-                                 (makeafrequest2DSA_MC_cluster.php), cg
+                                 (makeafrequest2DSA_MC_cluster.php - currently
+                                 DISABLED, see plans/autoflow-test-harness.md), cg
                                  (makeafrequest2DSA-CG.php, requires --customgrid)
 --customgrid          name    : required for --scenario cg. Must match an
                                  existing description in <db>.model - i.e. a
@@ -749,6 +750,12 @@ switch ( $mode ) {
     case "run": {
         if ( !is_dir( $gridctl_dir ) ) {
             error_exit( "ERROR: --gridctl-dir '$gridctl_dir' is not a directory" );
+        }
+        if ( $scenario === "mc-cluster" ) {
+            error_exit( "ERROR: --scenario mc-cluster is disabled - jobmonitor/cleanup_gfac.php has no" .
+                " ssh/scp result-retrieval path for non-local clusters, so a real remote-cluster run would" .
+                " submit fine but then hang/fail at result processing. See plans/autoflow-test-harness.md" .
+                " for details; re-enable this scenario once that retrieval code exists." );
         }
         $script = $gridctl_dir . "/autoflow_util/" . $scenario_scripts[ $scenario ];
         if ( !file_exists( $script ) ) {

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -93,7 +93,11 @@ Fault injection (opt-in, environment-only, never edits gridctl/common code)
                                  override, affecting any other in-flight jobs
                                  on a shared system. submitctl.php is restarted
                                  again with the original PATH once the watch
-                                 ends.
+                                 ends. Both restarts run as --expected-user
+                                 (via `su`), not whoever invokes this script, so
+                                 submitctl.php's owner is unchanged afterward -
+                                 this requires running this script as root (or
+                                 as --expected-user itself).
 
 __EOD;
 
@@ -664,9 +668,16 @@ function write_fake_sbatch( $test_bin_dir, $test_state_dir, $mode ) {
     return $path;
 }
 
-function restart_submitctl_with_path( $gridctl_dir, $prepend_path ) {
+## services.php's start() does no privilege-dropping itself (gridctl
+## services.php:87-100 just exec()s "nohup php $v &") - it inherits whatever
+## user calls "php services.php restart". Run it via su as $expected_user
+## explicitly so the restarted submitctl.php always ends up owned by the same
+## user it had before, regardless of which user is running this harness.
+function restart_submitctl_with_path( $gridctl_dir, $prepend_path, $expected_user ) {
     $path_env = $prepend_path ? "PATH=$prepend_path:\$PATH " : "";
-    echo run_cmd( "cd " . escapeshellarg( $gridctl_dir ) . " && $path_env php services.php restart 2>&1", false );
+    $inner = "cd " . escapeshellarg( $gridctl_dir ) . " && {$path_env}php services.php restart 2>&1";
+    $cmd = "su -s /bin/bash -c " . escapeshellarg( $inner ) . " " . escapeshellarg( $expected_user );
+    echo run_cmd( $cmd, false );
 }
 
 ####################################################################
@@ -692,7 +703,7 @@ switch ( $mode ) {
         if ( $fake_sbatch != "succeed" ) {
             echo "*** --fake-sbatch=$fake_sbatch enabled: restarting submitctl.php with a PATH override (this affects ANY in-flight jobs on this system) ***\n";
             $fake_path = write_fake_sbatch( $test_bin_dir, $test_state_dir, $fake_sbatch );
-            restart_submitctl_with_path( $gridctl_dir, $test_bin_dir );
+            restart_submitctl_with_path( $gridctl_dir, $test_bin_dir, $expected_user );
         }
 
         echo "Creating request via " . basename( $script ) . " $db $invid $rawid ...\n";
@@ -723,7 +734,7 @@ switch ( $mode ) {
 
         if ( $fake_sbatch != "succeed" ) {
             echo "*** restoring submitctl.php to its normal PATH ***\n";
-            restart_submitctl_with_path( $gridctl_dir, false );
+            restart_submitctl_with_path( $gridctl_dir, false, $expected_user );
         }
 
         if ( !$final ) {

--- a/uslims_autoflow_test.php
+++ b/uslims_autoflow_test.php
@@ -530,39 +530,47 @@ function run_check( $db, $expected_user, $web_user, $lock_dir, $home, $submit_lo
 ####################################################################
 
 function fetch_autoflow_row( $h, $db, $reqid ) {
-    $res = mysqli_query( $h, "SELECT requestID, status, statusMsg, statusJson, updateTime FROM ${db}.autoflowAnalysis WHERE requestID=$reqid" );
+    $res = mysqli_query( $h, "SELECT requestID, status, statusMsg, statusJson, updateTime, autoflowID, aprofileGUID FROM ${db}.autoflowAnalysis WHERE requestID=$reqid" );
     if ( !$res || !$res->num_rows ) {
         return false;
     }
     return mysqli_fetch_assoc( $res );
 }
 
-# Removes the autoflow/analysisprofile/autoflowAnalysis rows created by a
-# --run invocation, regardless of how the watch ended (FINISHED/FAILED/WAIT/
-# timeout) - they're synthetic test data either way. Opt-in only: a WAIT row
-# in particular can be a legitimate request a human still wants to finish by
-# hand, so this is never run unless --cleanup was explicitly given. Without
+# Removes the autoflow/analysisprofile/autoflowAnalysis(History) rows created
+# by a --run invocation, regardless of how the watch ended (FINISHED/FAILED/
+# WAIT/timeout) - they're synthetic test data either way. Opt-in only: a WAIT
+# row in particular can be a legitimate request a human still wants to finish
+# by hand, so this is never run unless --cleanup was explicitly given. Without
 # --cleanup, prints the equivalent DELETE statements so cleanup is still a
 # one-line copy-paste away.
-function cleanup_request( $db, $reqid, $do_cleanup ) {
+#
+# $autoflowid/$aprofileguid must come from the last row watch_request() saw
+# while polling, not a fresh lookup here: submitctl.php archives FINISHED/
+# FAILED rows into autoflowAnalysisHistory and deletes them from
+# autoflowAnalysis on its very next poll tick (submitctl.php:380-409), so by
+# the time cleanup runs the row may already be gone from autoflowAnalysis -
+# re-querying it here would silently fail to find autoflowID/aprofileGUID and
+# leave the related autoflow/analysisprofile rows orphaned.
+function cleanup_request( $db, $reqid, $autoflowid, $aprofileguid, $do_cleanup ) {
     $h = db_connect_lims();
-    $res = mysqli_query( $h, "SELECT autoflowID, aprofileGUID FROM ${db}.autoflowAnalysis WHERE requestID=$reqid" );
-    $row = $res ? mysqli_fetch_assoc( $res ) : false;
-    if ( !$row ) {
-        echo "[cleanup] requestID $reqid not found (already removed?) - nothing to do\n";
+
+    if ( !$autoflowid && !$aprofileguid ) {
+        echo "[cleanup] no autoflowID/aprofileGUID known for requestID $reqid - nothing to do\n";
         return;
     }
 
-    $aprofileguid_esc = mysqli_real_escape_string( $h, $row[ "aprofileGUID" ] );
-    $autoflowid        = (int) $row[ "autoflowID" ];
+    $aprofileguid_esc = mysqli_real_escape_string( $h, $aprofileguid );
+    $autoflowid        = (int) $autoflowid;
     $deletes = [
         "DELETE FROM ${db}.autoflowAnalysis WHERE requestID=$reqid",
+        "DELETE FROM ${db}.autoflowAnalysisHistory WHERE requestID=$reqid",
         "DELETE FROM ${db}.analysisprofile WHERE aprofileGUID='$aprofileguid_esc'",
         "DELETE FROM ${db}.autoflow WHERE ID=$autoflowid",
     ];
 
     if ( $do_cleanup ) {
-        echo "[cleanup] --cleanup given: removing test data for requestID=$reqid (autoflow ID=$autoflowid, analysisprofile aprofileGUID={$row['aprofileGUID']})\n";
+        echo "[cleanup] --cleanup given: removing test data for requestID=$reqid (autoflow ID=$autoflowid, analysisprofile aprofileGUID=$aprofileguid)\n";
         foreach ( $deletes as $sql ) {
             if ( !mysqli_query( $h, $sql ) ) {
                 echo "[cleanup] ERROR running '$sql': " . mysqli_error( $h ) . "\n";
@@ -584,6 +592,9 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
     $last_status_json = null;
     $start = time();
     $final = false;
+    $last_known = false; # last row seen while polling, kept even after the
+                          # row is archived/deleted by submitctl.php, so
+                          # cleanup_request() always has autoflowID/aprofileGUID
 
     while ( true ) {
         $row = fetch_autoflow_row( $h, $db, $reqid );
@@ -591,6 +602,7 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
             echo timestamp() . "[watch] requestID $reqid no longer found\n";
             break;
         }
+        $last_known = $row;
         if ( $row[ "statusJson" ] !== $last_status_json ) {
             echo timestamp() . "[watch] status={$row['status']} statusMsg={$row['statusMsg']} statusJson={$row['statusJson']}\n";
             $last_status_json = $row[ "statusJson" ];
@@ -621,7 +633,7 @@ function watch_request( $db, $reqid, $timeout, $poll_interval, $log_files ) {
 
     # final drain in case anything landed between the last poll and exit
     tail_state_poll( $tail_state );
-    return $final;
+    return [ "final" => $final, "last_known" => $last_known ];
 }
 
 ####################################################################
@@ -737,16 +749,21 @@ switch ( $mode ) {
             "dump"       => "$dump_dir/$db-$found_reqid.txt",
         ];
 
-        $final = watch_request( $db, $found_reqid, $timeout, $poll_interval, $log_files );
+        $watched = watch_request( $db, $found_reqid, $timeout, $poll_interval, $log_files );
+        $final = $watched[ "final" ];
+        $last_known = $watched[ "last_known" ];
 
         if ( $fake_sbatch != "succeed" ) {
             echo "*** restoring submitctl.php to its normal PATH ***\n";
             restart_submitctl_with_path( $gridctl_dir, false, $expected_user );
         }
 
+        $autoflowid    = $last_known ? $last_known[ "autoflowID" ] : false;
+        $aprofileguid  = $last_known ? $last_known[ "aprofileGUID" ] : false;
+
         if ( !$final ) {
             echo "RESULT: requestID $found_reqid disappeared mid-watch - FAIL\n";
-            cleanup_request( $db, $found_reqid, $cleanup );
+            cleanup_request( $db, $found_reqid, $autoflowid, $aprofileguid, $cleanup );
             exit( 1 );
         }
 
@@ -759,7 +776,7 @@ switch ( $mode ) {
             ? "RESULT: PASS (status matches expected '$expect_status')\n"
             : "RESULT: FAIL (status '{$final['status']}' != expected '$expect_status')\n";
 
-        cleanup_request( $db, $found_reqid, $cleanup );
+        cleanup_request( $db, $found_reqid, $autoflowid, $aprofileguid, $cleanup );
         exit( $passed ? 0 : 1 );
     }
 
@@ -771,7 +788,8 @@ switch ( $mode ) {
             "elog2.txt"  => $elog2_file,
             "dump"       => "$dump_dir/$db-$reqid.txt",
         ];
-        $final = watch_request( $db, $reqid, $timeout, $poll_interval, $log_files );
+        $watched = watch_request( $db, $reqid, $timeout, $poll_interval, $log_files );
+        $final = $watched[ "final" ];
         if ( !$final ) {
             exit( 1 );
         }


### PR DESCRIPTION
## Summary
- Adds `uslims_autoflow_test.php`, a standalone debug/monitor/validation tool for the autoflow GMP pipeline (`makeafrequest*.php` -> `submitctl.php` -> `submitone.php` -> `submit_local.php` -> `sbatch`/`qsub`), following the existing `uslims_jobs.php`/`uslims_autoflow.php` CLI conventions.
- `--check` (default, read-only): service status, lock-file PID/owner checks against `--expected-user`, writability/ownership of every log/lock path the daemons depend on, and a stale-`autoflowAnalysis`-rows query.
- `--run`/`--watch`: drives or watches a request through to `FINISHED`/`FAILED`/timeout while tailing every pipeline log file (`submit.log`, `udp.log`, `elog.txt`, `elog2.txt`, the per-request dump file).
- `--fake-sbatch fail-always|fail-once` (opt-in, requires `--yes-i-know-this-restarts-submitctl`): PATH-shadows `sbatch` to exercise `submitctl.php`/`submitone.php`'s failure paths (including PR ehb54/us3lims_gridctl#27's `check_cli_errors_in_dump()`) without ever editing gridctl/common source.
- Adds `plans/autoflow-test-harness.md` documenting the pipeline, log-file inventory, and design constraints this implements.

Fixes ehb54/ultrascan-tickets#930

## Test plan
- [ ] `--check` against a real GMP host reports accurate service/permission status
- [ ] `--run` against the Demo db drives a normal 2DSA-chain request through to `FINISHED`
- [ ] `--fake-sbatch fail-always` ends in `FAILED` with the expected error message
- [ ] `--fake-sbatch fail-once` exercises the retry path and still succeeds
