### PR TITLE
Default daily backup compression to pigz, overridable in db_config.php

### DIFF
--- a/db_config.php.template
+++ b/db_config.php.template
@@ -20,6 +20,9 @@ $backup_rdiff_temp    = "/srv/data/temp";      # path for temporary storage for 
 
 # $backup_file_mode     = "400";                 # if not defined, set as "400" (read only)
 
+# $compresswith         = "pigz -f";             # compressor for the sql dumps; default is "pigz -f", use "gzip -f" if pigz is unavailable
+# $compressext          = "gz";                  # file extension the compressor produces (match to $compresswith)
+
 $backup_df_pct_warn   = 80;                    # the warning threshold
 $backup_df_check      = [];                    # array of mounts to check for free space, leave empty for no checks
 

--- a/uslims_daily_backup.php
+++ b/uslims_daily_backup.php
@@ -3,7 +3,7 @@
 $self                 = __FILE__;
 $hdir                 = __DIR__;
 
-$compresswith         = "gzip -f";
+$compresswith         = "pigz -f";            # default compressor; override in db_config.php ($compresswith / $compressext)
 $compressext          = "gz";
 $rdiff_bin            = "/bin/rdiff";
 


### PR DESCRIPTION
## Summary

Switches the default compressor in `uslims_daily_backup.php` from `gzip -f` to `pigz -f` (parallel gzip, produces standard `.gz` output), and makes both the compressor command and its output extension overridable in `db_config.php`.

## Changes
- `uslims_daily_backup.php`: default `$compresswith` is now `pigz -f`.
- `db_config.php.template`: documents optional `$compresswith` / `$compressext` overrides. Since `db_config.php` is `require`d after the defaults are set, a site override there naturally wins.

## Note
The new default requires `pigz` to be installed on the backup host. Hosts without pigz can set `$compresswith = "gzip -f";` in `db_config.php`. If preferred, an auto-fallback to gzip when pigz is absent can be added as a follow-up.

Fixes ehb54/ultrascan-tickets#949

🤖 Generated with [Claude Code](https://claude.com/claude-code)