### PR TITLE
Add missing cluster alias

### DIFF
--- a/uslims_metadata_format.json
+++ b/uslims_metadata_format.json
@@ -104,6 +104,7 @@
             ,"gordon.sdsc.edu"                   : 12
             ,"gordon.sdsc.xsede.org"             : 13
             ,"H7-380489.ad.PSU.edu"              : 14
+            ,"h7-380489.huck.psu.edu"            : 14
             ,"jetstream.jetdomain"               : 15
             ,"js-157-184.jetstream-cloud.org"    : 16
             ,"js-169-137.jetstream-cloud.org"    : 16

--- a/uslims_metadata_format_max10datasets.json
+++ b/uslims_metadata_format_max10datasets.json
@@ -104,6 +104,7 @@
             ,"gordon.sdsc.edu"                   : 12
             ,"gordon.sdsc.xsede.org"             : 13
             ,"H7-380489.ad.PSU.edu"              : 14
+            ,"h7-380489.huck.psu.edu"            : 14
             ,"jetstream.jetdomain"               : 15
             ,"js-157-184.jetstream-cloud.org"    : 16
             ,"js-169-137.jetstream-cloud.org"    : 16


### PR DESCRIPTION
This pull request adds a new hostname mapping to both the `uslims_metadata_format.json` and `uslims_metadata_format_max10datasets.json` files to ensure consistent site identification.

Hostname mapping updates:

* Added `"h7-380489.huck.psu.edu"` mapped to site ID `14` in both `uslims_metadata_format.json` and `uslims_metadata_format_max10datasets.json` to align with existing mappings for PSU hosts. [[1]](diffhunk://#diff-29d53d9ca3ead50c987649a23177524a1a182c33f315c4ec0f1975e7b4d413c6R107) [[2]](diffhunk://#diff-4fbaff3b8d765e917478d3b5b27d1db37310826f0fb3e0a6f4bb64884dc39260R107)