### PR TITLE
util/csp: CSP audit tool and recommended policy

### DIFF
--- a/util/csp/README.md
+++ b/util/csp/README.md
@@ -1,0 +1,67 @@
+# CSP tooling
+
+Support for running USLIMS under a strict Content-Security-Policy.
+
+See ehb54/ultrascan-tickets#478.
+
+## csp-audit.sh
+
+Scans a checkout for constructs that `default-src 'self'` blocks and exits
+non-zero if it finds any, so it can gate a merge.
+
+```bash
+util/csp/csp-audit.sh /path/to/us3lims_dbinst /path/to/us3lims_common
+```
+
+It checks the sources rather than rendered pages. That is deliberate: most of
+this markup is emitted from PHP on paths that only fire for particular user
+levels, particular analysis types, or particular error conditions, and browser
+testing reliably misses them. It reports:
+
+| check | directive |
+|---|---|
+| inline `on*=` event handler attributes | `script-src` |
+| inline `<script>` blocks | `script-src` |
+| `javascript:` URLs | `script-src` |
+| `eval` / `new Function` / string timers | `script-src 'unsafe-eval'` |
+| inline `style=` attributes | `style-src` |
+| inline `<style>` blocks | `style-src` |
+| cross-origin `src=` / `data=` subresources | `default-src` |
+| cross-origin CSS `@import` / `url()` | `style-src`, `font-src`, `img-src` |
+| PHP tags inside `.js` files | — see below |
+
+Vendored libraries (`jquery*.js`) are skipped: they are loaded as external
+files, so their internals are not a CSP concern.
+
+`blob:` URL construction is reported separately and does **not** count as a
+violation — it is an input to the policy, not a defect. See below.
+
+### Why the PHP-in-`.js` check is here
+
+A `<?php ... ?>` tag inside a file served as `.js` never executes. The raw tag
+reaches the browser, the script fails to parse, and *every* function it defines
+becomes undefined. When those functions are the targets of delegated CSP
+handlers, the symptom is indistinguishable from a botched CSP conversion, so
+the check belongs next to the CSP checks. `js/GA_2.js` had exactly this
+problem.
+
+## Deploying the policy
+
+`csp-report-only.conf` is the recommended starting point. Deploy it in
+report-only mode first, collect for a full analysis cycle, then switch the
+header name to `Content-Security-Policy`.
+
+The policy is not simply `default-src 'self'`. Three additions are load-bearing:
+
+- **`blob:`** in `img-src`, `object-src` and `connect-src`. The supporting-files
+  viewer builds object URLs with `URL.createObjectURL()` and feeds them to
+  `<object data=>`, `<img src=>` and `fetch()`. `blob:` is not covered by
+  `'self'`, so without these the document viewer silently shows nothing.
+- **`form-action`, `base-uri`, `frame-ancestors`** must be stated explicitly.
+  None of them fall back to `default-src`, so a policy that omits them leaves
+  form submission targets, `<base>` injection and framing unrestricted.
+
+Note that `style-src 'self'` still permits JavaScript to set element styles
+through the CSSOM (`element.style.display = ...`, jQuery `.show()`, jQuery UI
+sliders). CSP only blocks style *attributes parsed from markup*. No code had to
+change for that.

--- a/util/csp/csp-audit.sh
+++ b/util/csp/csp-audit.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# csp-audit.sh -- report Content-Security-Policy violations in a USLIMS tree.
+#
+# Scans PHP/HTML/JS/CSS sources for constructs that a strict policy blocks:
+#
+#     Content-Security-Policy: default-src 'self'
+#
+# Static analysis of the sources, not of rendered pages, so it flags markup
+# that is only emitted on some code paths -- which is the point, since those
+# paths are the ones manual browser testing misses.
+#
+# usage: csp-audit.sh <directory> [<directory> ...]
+#
+# Exits 0 when clean, 1 when any violation is found, 2 on usage error.
+
+set -u
+
+usage() {
+    # print the leading comment block (everything after the shebang that is
+    # still a comment), with the leading "# " stripped
+    awk 'NR==1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 2
+fi
+
+for dir in "$@"; do
+    if [ ! -d "$dir" ]; then
+        echo "csp-audit: not a directory: $dir" >&2
+        exit 2
+    fi
+done
+
+total=0
+
+# Vendored libraries are third-party and are loaded as external files, so their
+# internals are not a CSP concern.  .git and node_modules are noise.
+PRUNE=( -name .git -o -name node_modules -o -name 'jquery*.js' )
+
+sources() {
+    local ext="$1"; shift
+    find "$@" \( "${PRUNE[@]}" \) -prune -o -type f -name "$ext" -print
+}
+
+report() {
+    local title="$1" advice="$2" count="$3" body="$4"
+    if [ "$count" -gt 0 ]; then
+        echo "== $title: $count =="
+        echo "$body" | sed 's|^|   |'
+        echo "   -> $advice"
+        echo
+    fi
+}
+
+
+echo "CSP audit of: $*"
+echo "policy assumed: default-src 'self'"
+echo
+
+# --- script-src ------------------------------------------------------------
+
+HANDLERS='\bon(abort|blur|change|click|dblclick|error|focus|input|invalid|keydown|keypress|keyup|load|mousedown|mousemove|mouseout|mouseover|mouseup|paste|reset|resize|scroll|search|select|submit|toggle|unload|wheel)\s*='
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" )
+hits=$( echo "$hits" | xargs grep -nEI "$HANDLERS" 2>/dev/null \
+        | grep -vE ':[0-9]+:\s*(//|#|\*)' \
+        | grep -vE '\$on[a-z]+\s*=' )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "inline event handler attributes" \
+       "move to a delegated listener keyed on a class or id" "$n" "$hits"
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" )
+hits=$( echo "$hits" | xargs grep -nI '<script' 2>/dev/null | grep -v 'src=' )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "inline <script> blocks" \
+       "move the body into a .js file and load it with <script src>" "$n" "$hits"
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" ; sources '*.js' "$@" )
+hits=$( echo "$hits" | xargs grep -nIE "(href|action|src)\s*=\s*['\"]?javascript:" 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "javascript: URLs" \
+       "replace with a class and a delegated listener" "$n" "$hits"
+
+hits=$( sources '*.js' "$@" ; sources '*.php' "$@" )
+hits=$( echo "$hits" | xargs grep -nIE "\beval\s*\(|new Function\s*\(|set(Timeout|Interval)\s*\(\s*['\"]" 2>/dev/null \
+        | grep -vE ':[0-9]+:\s*(//|\*)' )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "eval / Function / string timers" \
+       "rewrite without dynamic code; otherwise the policy needs 'unsafe-eval'" "$n" "$hits"
+
+# --- style-src -------------------------------------------------------------
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" )
+hits=$( echo "$hits" | xargs grep -nIE "\bstyle\s*=\s*[\"']" 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "inline style= attributes" \
+       "replace with a class in a stylesheet" "$n" "$hits"
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" )
+hits=$( echo "$hits" | xargs grep -nI '<style' 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "inline <style> blocks" \
+       "move into a .css file loaded via \$css" "$n" "$hits"
+
+# --- default-src: subresource origins --------------------------------------
+
+hits=$( sources '*.php' "$@" ; sources '*.html' "$@" )
+hits=$( echo "$hits" | xargs grep -nIE "(src|data)\s*=\s*['\"]https?://" 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "cross-origin subresource loads" \
+       "self-host the asset, or add the origin to the policy" "$n" "$hits"
+
+hits=$( sources '*.css' "$@" )
+hits=$( echo "$hits" | xargs grep -nIE "@import|url\(\s*['\"]?https?:" 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "cross-origin CSS imports / url()" \
+       "self-host the asset, or add the origin to the policy" "$n" "$hits"
+
+# --- correctness checks that silently disable CSP handlers ------------------
+
+# A PHP tag inside a .js file never executes -- the file is served statically,
+# so the raw tag reaches the browser and the whole script fails to parse.  Every
+# function in it is then undefined, including any the delegated CSP handlers
+# call, which looks exactly like a broken CSP conversion.
+hits=$( sources '*.js' "$@" )
+hits=$( echo "$hits" | xargs grep -nI '<?php\|<?=' 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+total=$(( total + n ))
+report "PHP tags inside .js files" \
+       "pass the value through a data- attribute instead" "$n" "$hits"
+
+# --- informational: blob:/data: need explicit policy allowances ------------
+
+hits=$( sources '*.js' "$@" )
+hits=$( echo "$hits" | xargs grep -nI 'createObjectURL' 2>/dev/null )
+n=$( [ -n "$hits" ] && echo "$hits" | wc -l | tr -d ' ' || echo 0 )
+if [ "$n" -gt 0 ]; then
+    echo "== blob: URL construction (policy input, not a source defect): $n =="
+    echo "$hits" | sed 's|^|   |'
+    echo "   -> blob: does not fall under 'self'.  Any img/object/fetch that"
+    echo "      consumes these needs blob: named in img-src / object-src /"
+    echo "      connect-src.  Not counted as a violation."
+    echo
+fi
+
+# --- verdict ---------------------------------------------------------------
+
+if [ "$total" -eq 0 ]; then
+    echo "CLEAN: no violations of default-src 'self' found."
+    exit 0
+fi
+
+echo "FOUND $total violation(s)."
+exit 1

--- a/util/csp/csp-report-only.conf
+++ b/util/csp/csp-report-only.conf
@@ -1,0 +1,58 @@
+# Content-Security-Policy for USLIMS -- Apache httpd.conf / vhost fragment.
+#
+# See ehb54/ultrascan-tickets#478 and util/csp/README.md.
+#
+# Deploy THIS file first.  Content-Security-Policy-Report-Only sends violation
+# reports to the browser console without blocking anything, so a full analysis
+# cycle can be run against it with no risk to users.  Once the console is quiet
+# across every page, rename the header to Content-Security-Policy to enforce.
+#
+# Requires mod_headers.
+
+<IfModule mod_headers.c>
+
+    Header always set Content-Security-Policy-Report-Only "\
+default-src 'self'; \
+script-src 'self'; \
+style-src 'self'; \
+img-src 'self' blob:; \
+object-src 'self' blob:; \
+connect-src 'self' blob:; \
+font-src 'self'; \
+frame-src 'none'; \
+frame-ancestors 'self'; \
+form-action 'self'; \
+base-uri 'self'"
+
+</IfModule>
+
+# Directive notes
+# ---------------
+#
+# img-src / object-src / connect-src include blob:
+#     The supporting-files document viewer builds object URLs with
+#     URL.createObjectURL() and hands them to <object data=>, <img src=> and
+#     fetch().  blob: is NOT covered by 'self'.  Drop these and the viewer
+#     silently displays nothing.
+#
+# frame-ancestors / form-action / base-uri
+#     None of these fall back to default-src.  Omitting them leaves framing,
+#     form submission targets and <base> injection unrestricted no matter how
+#     strict default-src is.
+#
+# frame-src 'none'
+#     Nothing in USLIMS frames third-party content.  Relax only if that changes.
+#
+# style-src 'self'
+#     Sufficient.  CSP blocks style attributes parsed from markup, not styles
+#     set through the CSSOM, so element.style.display, jQuery .show()/.hide()
+#     and jQuery UI sliders all keep working.
+#
+# No 'unsafe-inline', no 'unsafe-eval', no nonces, no hashes
+#     Every inline handler, inline <script> and inline style= has been removed
+#     from us3lims_dbinst and us3lims_common.  Verify before enforcing:
+#
+#         util/csp/csp-audit.sh /path/to/us3lims_dbinst /path/to/us3lims_common
+#
+#     Adding 'unsafe-inline' back to script-src would forfeit essentially all
+#     of the XSS protection the policy buys.


### PR DESCRIPTION
Tooling for ehb54/ultrascan-tickets#478, so "is it CSP-clean?" has an answer that is checked rather than asserted.

Supports **ehb54/us3lims_dbinst#64** and **ehb54/us3lims_common#26**, which take those two repos to zero violations.

### `util/csp/csp-audit.sh`

Scans a checkout for constructs that `default-src 'self'` blocks and exits non-zero if it finds any, so it can gate a merge.

```bash
util/csp/csp-audit.sh /path/to/us3lims_dbinst /path/to/us3lims_common
```

Source analysis rather than page rendering — deliberately. Most of this markup is emitted from PHP on paths that only fire for particular user levels, analysis types or error conditions, and browser testing reliably misses them.

Covers inline `on*=` handlers, inline `<script>`, `javascript:` URLs, `eval`/`new Function`/string timers, inline `style=`, inline `<style>`, cross-origin subresources, and cross-origin CSS `@import`/`url()`. Vendored `jquery*.js` is skipped — loaded as an external file, so its internals are not a CSP concern.

**Validated both directions:** 225 violations against current `main` of the two repos, 0 against the issue-478 branches. A checker that has never been seen to fail isn't a checker.

It also flags **PHP tags inside `.js` files**. Not a CSP rule, but the failure mode is indistinguishable from a botched conversion: the tag never executes, the whole script fails to parse, and every function it defines — including the targets of delegated handlers — becomes undefined. `js/GA_2.js` had exactly this, which is why `validate_solutes()` and `get_solute_count()` were undefined on that page.

### `util/csp/csp-report-only.conf`

The policy to deploy first, in report-only mode. It is **not** plain `default-src 'self'` — two groups of additions are load-bearing:

- **`blob:` in `img-src`, `object-src`, `connect-src`.** The supporting-files document viewer builds object URLs with `URL.createObjectURL()` and feeds them to `<object data=>`, `<img src=>` and `fetch()`. `blob:` is not covered by `'self'`; without these the viewer silently displays nothing.
- **`form-action`, `base-uri`, `frame-ancestors` stated explicitly.** None of them fall back to `default-src`, so a policy that omits them leaves form targets, `<base>` injection and framing unrestricted however strict `default-src` is.

Worth noting `style-src 'self'` needed no code changes beyond removing markup `style=` attributes: CSP does not block styles set through the CSSOM, so `element.style.display`, jQuery `.show()`/`.hide()` and jQuery UI sliders keep working.

### Validation

Covered by a 69-test manual plan in the internal test-management project, tracked from ehb54/ultrascan-tickets#478. Suites S1–S2 exercise the jQuery / jQuery UI upgrade, S3–S8 the handler conversions, S9 the policy itself, S10 deployment and rollback.

S1–S8 are run with no CSP header set, to separate a mis-wired handler from a policy block; S9 re-runs the critical path under report-only before enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

